### PR TITLE
chore: rename sendToAlbyAccount to sendBoostagramToAlbyAccount

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Please have a look a the Alby OAuth2 Wallet API:
 - keysend
 - sendPayment
 - sendBoostagram
-- sendToAlbyAccount
+- sendBoostagramToAlbyAccount
 - createWebhookEndpoint
 - deleteWebhookEndpoint
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -225,6 +225,16 @@ export class Client {
     });
   }
 
+  /**
+   * @deprecated please use sendBoostagramToAlbyAccount
+   */
+  sendToAlbyAccount(
+    args: SendBoostagramToAlbyRequestParams,
+    request_options?: Partial<RequestOptions>,
+  ) {
+    return this.sendBoostagramToAlbyAccount(args, request_options);
+  }
+
   sendBoostagramToAlbyAccount(
     args: SendBoostagramToAlbyRequestParams,
     request_options?: Partial<RequestOptions>,

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,7 +17,7 @@ import {
   SendBoostagramRequestParams,
   SendPaymentRequestParams,
   SendPaymentResponse,
-  SendToAlbyRequestParams,
+  SendBoostagramToAlbyRequestParams,
   SwapInfoResponse,
 } from "./types";
 
@@ -37,6 +37,7 @@ export class Client {
   }
 
   accountBalance(
+    // eslint-disable-next-line @typescript-eslint/ban-types
     params: {},
     request_options?: Partial<RequestOptions>,
   ): Promise<GetAccountBalanceResponse> {
@@ -50,7 +51,11 @@ export class Client {
     });
   }
 
-  accountSummary(params: {}, request_options?: Partial<RequestOptions>) {
+  accountSummary(
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    params: {},
+    request_options?: Partial<RequestOptions>,
+  ) {
     return rest({
       auth: this.auth,
       ...this.defaultRequestOptions,
@@ -62,6 +67,7 @@ export class Client {
   }
 
   accountInformation(
+    // eslint-disable-next-line @typescript-eslint/ban-types
     params: {},
     request_options?: Partial<RequestOptions>,
   ): Promise<GetAccountInformationResponse> {
@@ -75,7 +81,11 @@ export class Client {
     });
   }
 
-  accountValue4Value(params: {}, request_options?: Partial<RequestOptions>) {
+  accountValue4Value(
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    params: {},
+    request_options?: Partial<RequestOptions>,
+  ) {
     return rest({
       auth: this.auth,
       ...this.defaultRequestOptions,
@@ -215,8 +225,8 @@ export class Client {
     });
   }
 
-  sendToAlbyAccount(
-    args: SendToAlbyRequestParams,
+  sendBoostagramToAlbyAccount(
+    args: SendBoostagramToAlbyRequestParams,
     request_options?: Partial<RequestOptions>,
   ) {
     const params = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,6 +132,11 @@ export type SendBoostagramToAlbyRequestParams = {
   memo?: string;
 };
 
+/**
+ * @deprecated please use SendBoostagramToAlbyRequestParams
+ */
+export type SendToAlbyRequestParams = SendBoostagramToAlbyRequestParams;
+
 export type CreateWebhookEndpointParams = {
   url: string;
   description?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,11 +63,11 @@ export abstract class AuthClient {
 }
 
 // https://stackoverflow.com/a/50375286
-export type UnionToIntersection<U> = (
-  U extends any ? (k: U) => void : never
-) extends (k: infer I) => void
-  ? I
-  : never;
+export type UnionToIntersection<U> =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (U extends any ? (k: U) => void : never) extends (k: infer I) => void
+    ? I
+    : never;
 
 export type GetSuccess<T> = {
   [K in SuccessStatus & keyof T]: GetContent<T[K]>;
@@ -85,7 +85,7 @@ export type ExtractAlbyResponse<T> = "responses" extends keyof T
   ? GetSuccess<T["responses"]>
   : never;
 
-export type GetInvoicesRequestParams = {  
+export type GetInvoicesRequestParams = {
   q?: {
     since?: string;
     created_at_lt?: string;
@@ -123,7 +123,10 @@ export type SendBoostagramRequestParams = {
   amount: number;
 };
 
-export type SendToAlbyRequestParams = {
+export type SendBoostagramToAlbyRequestParams = {
+  /**
+   * the keysend custom value found at https://getalby.com/node
+   */
   account: string;
   amount: number;
   memo?: string;


### PR DESCRIPTION
**BREAKING CHANGE**

This is a keysend request so I think this naming makes more sense