### PR TITLE
fix: allow choosing request methods in authorization url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getalby/sdk",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "The SDK to integrate with Nostr Wallet Connect and the Alby API",
   "repository": "https://github.com/getAlby/js-sdk.git",
   "bugs": "https://github.com/getAlby/js-sdk/issues",

--- a/src/types.ts
+++ b/src/types.ts
@@ -229,8 +229,14 @@ export type Invoice = {
   };
 } & Record<string, unknown>;
 
-export type GetNWCAuthorizationUrlOptions = {
+/**
+ * @deprecated please use NWCAuthorizationUrlOptions
+ */
+export type GetNWCAuthorizationUrlOptions = NWCAuthorizationUrlOptions;
+
+export type NWCAuthorizationUrlOptions = {
   name?: string;
+  requestMethods?: string[];
   returnTo?: string;
   expiresAt?: Date;
   maxAmount?: number;

--- a/src/webln/NostrWeblnProvider.test.ts
+++ b/src/webln/NostrWeblnProvider.test.ts
@@ -15,10 +15,11 @@ describe("isValidAmount", () => {
           maxAmount: 100,
           name: "TestApp",
           returnTo: "https://example.com",
+          requestMethods: ["pay_invoice", "get_balance"],
         })
         .toString(),
     ).toEqual(
-      "https://nwc.getalby.com/apps/new?c=TestApp&pubkey=c5dc47856f533dad6c016b979ee3b21f83f88ae0f0058001b67a4b348339fe94&return_to=https%3A%2F%2Fexample.com&budget_renewal=weekly&expires_at=1689897600&max_amount=100&editable=false",
+      "https://nwc.getalby.com/apps/new?name=TestApp&pubkey=c5dc47856f533dad6c016b979ee3b21f83f88ae0f0058001b67a4b348339fe94&return_to=https%3A%2F%2Fexample.com&budget_renewal=weekly&expires_at=1689897600&max_amount=100&editable=false&request_methods=pay_invoice+get_balance",
     );
   });
 });


### PR DESCRIPTION
also rename c to name (already supported by nwc)