### PR TITLE
feat: add NWC client method to get wallet service supported methods

### DIFF
--- a/examples/nwc/client/get-wallet-service-supported-methods.js
+++ b/examples/nwc/client/get-wallet-service-supported-methods.js
@@ -14,8 +14,11 @@ const nwcUrl =
   (await rl.question("Nostr Wallet Connect URL (nostr+walletconnect://...): "));
 rl.close();
 
-const response = await nwc.NWCClient.getWalletServiceSupportedMethods(
-  nwc.NWCClient.parseWalletConnectUrl(nwcUrl),
-);
+const client = new nwc.NWCClient({
+  nostrWalletConnectUrl: nwcUrl,
+});
+const response = await client.getWalletServiceSupportedMethods();
 
 console.info(response);
+
+client.close();

--- a/examples/nwc/client/get-wallet-service-supported-methods.js
+++ b/examples/nwc/client/get-wallet-service-supported-methods.js
@@ -1,0 +1,21 @@
+import * as crypto from "node:crypto"; // required in node.js
+global.crypto = crypto; // required in node.js
+import "websocket-polyfill"; // required in node.js
+
+import * as readline from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+
+import { nwc } from "../../../dist/index.module.js";
+
+const rl = readline.createInterface({ input, output });
+
+const nwcUrl =
+  process.env.NWC_URL ||
+  (await rl.question("Nostr Wallet Connect URL (nostr+walletconnect://...): "));
+rl.close();
+
+const response = await nwc.NWCClient.getWalletServiceSupportedMethods(
+  nwc.NWCClient.parseWalletConnectUrl(nwcUrl),
+);
+
+console.info(response);


### PR DESCRIPTION
As per https://github.com/nostr-protocol/nips/blob/master/47.md#theory-of-operation to get "info" (actually just supported methods) from the relay