### PR TITLE
feat: add NWC sign message method

### DIFF
--- a/examples/nwc/client/sign-message.js
+++ b/examples/nwc/client/sign-message.js
@@ -1,0 +1,27 @@
+import * as crypto from "node:crypto"; // required in node.js
+global.crypto = crypto; // required in node.js
+import "websocket-polyfill"; // required in node.js
+
+import * as readline from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+
+import { nwc } from "../../../dist/index.module.js";
+
+const rl = readline.createInterface({ input, output });
+
+const nwcUrl =
+  process.env.NWC_URL ||
+  (await rl.question("Nostr Wallet Connect URL (nostr+walletconnect://...): "));
+
+rl.close();
+
+const client = new nwc.NWCClient({
+  nostrWalletConnectUrl: nwcUrl,
+});
+const response = await client.signMessage({
+  message: "Hello, world!",
+});
+
+console.info(response);
+
+client.close();

--- a/examples/nwc/sign-message.js
+++ b/examples/nwc/sign-message.js
@@ -1,0 +1,26 @@
+import * as crypto from "node:crypto"; // required in node.js
+global.crypto = crypto; // required in node.js
+import "websocket-polyfill"; // required in node.js
+
+import * as readline from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+
+import { webln as providers } from "../../dist/index.module.js";
+
+const rl = readline.createInterface({ input, output });
+
+const nwcUrl =
+  process.env.NWC_URL ||
+  (await rl.question("Nostr Wallet Connect URL (nostr+walletconnect://...): "));
+
+rl.close();
+
+const webln = new providers.NostrWebLNProvider({
+  nostrWalletConnectUrl: nwcUrl,
+});
+await webln.enable();
+const response = await webln.signMessage("Hello, world!");
+
+console.info(response);
+
+webln.close();

--- a/src/NWCClient.ts
+++ b/src/NWCClient.ts
@@ -27,7 +27,8 @@ type Nip47SingleMethod =
   | "pay_invoice"
   | "pay_keysend"
   | "lookup_invoice"
-  | "list_transactions";
+  | "list_transactions"
+  | "sign_message";
 
 type Nip47MultiMethod = "multi_pay_invoice" | "multi_pay_keysend";
 
@@ -120,6 +121,15 @@ export type Nip47MakeInvoiceRequest = {
 export type Nip47LookupInvoiceRequest = {
   payment_hash?: string;
   invoice?: string;
+};
+
+export type Nip47SignMessageRequest = {
+  message: string;
+};
+
+export type Nip47SignMessageResponse = {
+  message: string;
+  signature: string;
 };
 
 export interface NWCOptions {
@@ -469,6 +479,22 @@ export class NWCClient {
       return result;
     } catch (error) {
       console.error("Failed to request pay_keysend", error);
+      throw error;
+    }
+  }
+  async signMessage(
+    request: Nip47SignMessageRequest,
+  ): Promise<Nip47SignMessageResponse> {
+    try {
+      const result = await this.executeNip47Request<Nip47SignMessageResponse>(
+        "sign_message",
+        request,
+        (result) => result.message === request.message && !!result.signature,
+      );
+
+      return result;
+    } catch (error) {
+      console.error("Failed to request sign_message", error);
       throw error;
     }
   }


### PR DESCRIPTION
Related to https://github.com/getAlby/nostr-wallet-connect-next/issues/108

- [ ] propose method to NIP-47?

Example output:

```
node examples/nwc/sign-message.js 
{
  message: 'Hello, world!',
  signature: 'd9s5fyzwmjpyxej81kaz1iqqhn356epba4eokducjwc3n517dbg1sopi9hqkjunhpx5af4hxo9xrzx3y95x4ra73fko1qpffuajio1au'
}
```