### PR TITLE
feat: read supported notification types from wallet service info notifications tag

### DIFF
--- a/examples/nwc/client/get-wallet-service-info.js
+++ b/examples/nwc/client/get-wallet-service-info.js
@@ -1,0 +1,24 @@
+import * as crypto from "node:crypto"; // required in node.js
+global.crypto = crypto; // required in node.js
+import "websocket-polyfill"; // required in node.js
+
+import * as readline from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+
+import { nwc } from "../../../dist/index.module.js";
+
+const rl = readline.createInterface({ input, output });
+
+const nwcUrl =
+  process.env.NWC_URL ||
+  (await rl.question("Nostr Wallet Connect URL (nostr+walletconnect://...): "));
+rl.close();
+
+const client = new nwc.NWCClient({
+  nostrWalletConnectUrl: nwcUrl,
+});
+const response = await client.getWalletServiceInfo();
+
+console.info(response);
+
+client.close();

--- a/src/NWCClient.ts
+++ b/src/NWCClient.ts
@@ -33,6 +33,7 @@ type Nip47SingleMethod =
 type Nip47MultiMethod = "multi_pay_invoice" | "multi_pay_keysend";
 
 export type Nip47Method = Nip47SingleMethod | Nip47MultiMethod;
+export type Nip47Capability = Nip47Method | "notifications";
 
 export type Nip47GetInfoResponse = {
   alias: string;
@@ -98,6 +99,8 @@ export type Nip47Transaction = {
   expires_at: number;
   metadata?: Record<string, unknown>;
 };
+
+export type Nip47NotificationType = Nip47Notification["notification_type"];
 
 export type Nip47Notification = {
   notification_type: "payment_received";
@@ -398,7 +401,22 @@ export class NWCClient {
     });
   }
 
-  async getWalletServiceSupportedMethods(): Promise<Nip47Method[]> {
+  /**
+   * @deprecated please use getWalletServiceInfo. Deprecated since v3.5.0. Will be removed in v4.0.0.
+   */
+  async getWalletServiceSupportedMethods(): Promise<Nip47Capability[]> {
+    console.warn(
+      "getWalletServiceSupportedMethods is deprecated. Please use getWalletServiceInfo instead.",
+    );
+    const info = await this.getWalletServiceInfo();
+
+    return info.capabilities;
+  }
+
+  async getWalletServiceInfo(): Promise<{
+    capabilities: Nip47Capability[];
+    notifications: Nip47NotificationType[];
+  }> {
     await this._checkConnected();
 
     const events = await this.relay.list(
@@ -417,9 +435,16 @@ export class NWCClient {
     if (!events.length) {
       throw new Error("no info event (kind 13194) returned from relay");
     }
-    const result = events[0].content;
-    // delimiter is " " per spec, but Alby NWC originally returned ","
-    return result.split(/[ |,]/g) as Nip47Method[];
+    const content = events[0].content;
+    const notificationsTag = events[0].tags.find(
+      (t) => t[0] === "notifications",
+    );
+    return {
+      // delimiter is " " per spec, but Alby NWC originally returned ","
+      capabilities: content.split(/[ |,]/g) as Nip47Method[],
+      notifications: (notificationsTag?.[1]?.split(" ") ||
+        []) as Nip47NotificationType[],
+    };
   }
 
   async getInfo(): Promise<Nip47GetInfoResponse> {


### PR DESCRIPTION
Update to use `notifications` capability and read notification types from notification tag 

https://github.com/nostr-protocol/nips/pull/1164