### PR TITLE
fix: pass TLV value as hex from nwc webln provider to nwc client keysend

### DIFF
--- a/examples/nwc/client/multi-pay-keysend.js
+++ b/examples/nwc/client/multi-pay-keysend.js
@@ -17,6 +17,26 @@ const client = new nwc.NWCClient({
   nostrWalletConnectUrl: nwcUrl,
 });
 
+// Data from https://podcastindex.org/podcast/920666
+const boost = {
+  action: "boost",
+  value_msat: 1000,
+  value_msat_total: 1000,
+  app_name: "⚡ WebLN Demo",
+  app_version: "1.0",
+  feedID: "https://feeds.podcastindex.org/pc20.xml",
+  podcast: "Podcasting 2.0",
+  episode: "Episode 104: A New Dump",
+  ts: 21,
+  name: "⚡ WebLN Demo",
+  sender_name: "Sathoshi Nakamoto",
+  message: "Go podcasting!",
+};
+
+// from https://stackoverflow.com/a/50868276
+const toHexString = (bytes) =>
+  bytes.reduce((str, byte) => str + byte.toString(16).padStart(2, "0"), "");
+
 const keysends = [
   {
     pubkey:
@@ -25,11 +45,11 @@ const keysends = [
     tlv_records: [
       {
         type: 696969,
-        value: "017rsl75kNnSke4mMHYE", // hello@getalby.com
+        value: toHexString(new TextEncoder().encode("017rsl75kNnSke4mMHYE")), // hello@getalby.com
       },
       {
-        type: 34349334,
-        value: "first keysend message",
+        type: 7629169,
+        value: toHexString(new TextEncoder().encode(JSON.stringify(boost))),
       },
     ],
   },
@@ -40,11 +60,11 @@ const keysends = [
     tlv_records: [
       {
         type: 696969,
-        value: "1KOZHzhLs2U7JIx3BmEY", // another Alby account
+        value: toHexString(new TextEncoder().encode("1KOZHzhLs2U7JIx3BmEY")), // another Alby account
       },
       {
-        type: 34349334,
-        value: "second keysend message",
+        type: 7629169,
+        value: toHexString(new TextEncoder().encode(JSON.stringify(boost))),
       },
     ],
   },

--- a/examples/nwc/client/multi-pay-keysend.js
+++ b/examples/nwc/client/multi-pay-keysend.js
@@ -29,7 +29,7 @@ const boost = {
   episode: "Episode 104: A New Dump",
   ts: 21,
   name: "⚡ WebLN Demo",
-  sender_name: "Sathoshi Nakamoto",
+  sender_name: "Satoshi Nakamoto",
   message: "Go podcasting!",
 };
 

--- a/examples/nwc/client/pay-keysend.js
+++ b/examples/nwc/client/pay-keysend.js
@@ -17,17 +17,38 @@ rl.close();
 const client = new nwc.NWCClient({
   nostrWalletConnectUrl: nwcUrl,
 });
+
+// from https://stackoverflow.com/a/50868276
+const toHexString = (bytes) =>
+  bytes.reduce((str, byte) => str + byte.toString(16).padStart(2, "0"), "");
+
+// Data from https://podcastindex.org/podcast/920666
+const boost = {
+  action: "boost",
+  value_msat: 1000,
+  value_msat_total: 1000,
+  app_name: "⚡ WebLN Demo",
+  app_version: "1.0",
+  feedID: "https://feeds.podcastindex.org/pc20.xml",
+  podcast: "Podcasting 2.0",
+  episode: "Episode 104: A New Dump",
+  ts: 21,
+  name: "⚡ WebLN Demo",
+  sender_name: "Sathoshi Nakamoto",
+  message: "Go podcasting!",
+};
+
 const response = await client.payKeysend({
   amount: 1000, // millisats
   pubkey: "030a58b8653d32b99200a2334cfe913e51dc7d155aa0116c176657a4f1722677a3",
   tlv_records: [
     {
       type: 696969,
-      value: "017rsl75kNnSke4mMHYE", // hello@getalby.com
+      value: toHexString(new TextEncoder().encode("017rsl75kNnSke4mMHYE")), // hello@getalby.com
     },
     {
-      type: 34349334,
-      value: "example keysend message",
+      type: 7629169,
+      value: toHexString(new TextEncoder().encode(JSON.stringify(boost))),
     },
   ],
 });

--- a/examples/nwc/client/pay-keysend.js
+++ b/examples/nwc/client/pay-keysend.js
@@ -34,7 +34,7 @@ const boost = {
   episode: "Episode 104: A New Dump",
   ts: 21,
   name: "⚡ WebLN Demo",
-  sender_name: "Sathoshi Nakamoto",
+  sender_name: "Satoshi Nakamoto",
   message: "Go podcasting!",
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getalby/sdk",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "The SDK to integrate with Nostr Wallet Connect and the Alby API",
   "repository": "https://github.com/getAlby/js-sdk.git",
   "bugs": "https://github.com/getAlby/js-sdk/issues",

--- a/src/webln/NostrWeblnProvider.ts
+++ b/src/webln/NostrWeblnProvider.ts
@@ -23,6 +23,7 @@ import {
   Nip47PayKeysendRequest,
   Nip47Transaction,
 } from "../NWCClient";
+import { toHexString } from "../utils";
 
 // TODO: review fields (replace with camelCase)
 // TODO: consider move to webln-types package
@@ -509,7 +510,7 @@ function mapKeysendToNip47Keysend(args: KeysendArgs): Nip47PayKeysendRequest {
     tlv_records: args.customRecords
       ? Object.entries(args.customRecords).map((v) => ({
           type: parseInt(v[0]),
-          value: v[1],
+          value: toHexString(new TextEncoder().encode(v[1])),
         }))
       : [],
     // TODO: support optional preimage


### PR DESCRIPTION
With WebLN keysend TLVs, the value is passed as plaintext:
https://www.webln.guide/building-lightning-apps/webln-reference/webln.keysend

In NIP-47 spec the value should be hex encoded:
https://github.com/nostr-protocol/nips/blob/master/47.md#pay_keysend

This PR fixes the NostrWeblnProvider to pass the TLV values hex-encoded instead of plaintext.