### PR TITLE
feat: allow passing metadata in nwc pay_invoice and multi_pay_invoice

### DIFF
--- a/src/NWCClient.ts
+++ b/src/NWCClient.ts
@@ -127,6 +127,7 @@ export type Nip47Notification =
 
 export type Nip47PayInvoiceRequest = {
   invoice: string;
+  metadata?: unknown;
   amount?: number; // msats
 };
 


### PR DESCRIPTION
Alby Hub can store this data, enabling interesting applications to be developed, and finally enable a nice way to store payment metadata.