### PR TITLE
chore: add optional metadata field to get_info response

### DIFF
--- a/src/NWCClient.ts
+++ b/src/NWCClient.ts
@@ -47,6 +47,7 @@ export type Nip47GetInfoResponse = {
   block_hash: string;
   methods: Nip47Method[];
   notifications?: Nip47NotificationType[];
+  metadata?: unknown;
 };
 
 export type Nip47GetBudgetResponse =


### PR DESCRIPTION
Example response:
```
{
  alias: 'NWC',
  color: '#897FFF',
  pubkey: '03a078ec02e002be52c961b3fcc3c0d92f096b8a86844e256ad6f03aadbbc703ce',
  network: 'signet',
  block_height: 1766902,
  block_hash: '000000e5c972792fafc5ac45ffe216a2d44340f7de813267149302e4e4a60573',
  methods: [
    'pay_invoice',
    'pay_keysend',
    'multi_pay_invoice',
    'multi_pay_keysend',
    'get_info',
    'get_balance',
    'make_invoice',
    'lookup_invoice',
    'list_transactions',
    'sign_message',
    'get_budget'
  ],
  notifications: [ 'payment_received', 'payment_sent' ],
  metadata: { app_store_app_id: 'habla-news', id: 57, name: 'Habla News' }
}
```