### PR TITLE
fix: re-subscribe after relay disconnections in NWAClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getalby/sdk",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "The SDK to integrate with Nostr Wallet Connect and the Alby API",
   "repository": "https://github.com/getAlby/js-sdk.git",
   "bugs": "https://github.com/getAlby/js-sdk/issues",

--- a/src/NWAClient.ts
+++ b/src/NWAClient.ts
@@ -7,6 +7,7 @@ import {
   Nip47NotificationType,
   NWCClient,
 } from "./NWCClient";
+import { Subscription } from "nostr-tools/lib/types/abstract-relay";
 
 export type NWAOptions = {
   relayUrl: string;
@@ -170,47 +171,87 @@ export class NWAClient {
   }): Promise<{
     unsub: () => void;
   }> {
-    await this._checkConnected();
+    let subscribed = true;
+    let endPromise: (() => void) | undefined;
+    let onRelayDisconnect: (() => void) | undefined;
+    let sub: Subscription | undefined;
+    (async () => {
+      while (subscribed) {
+        try {
+          await this._checkConnected();
 
-    const sub = this.relay.subscribe(
-      [
-        {
-          kinds: [13194], // NIP-47 info event
-          "#p": [this.options.appPubkey],
-        },
-      ],
-      {
-        // eoseTimeout: 10000,
-      },
-    );
+          const sub = this.relay.subscribe(
+            [
+              {
+                kinds: [13194], // NIP-47 info event
+                "#p": [this.options.appPubkey],
+              },
+            ],
+            {
+              // eoseTimeout: 10000,
+            },
+          );
+          console.info("subscribed to relay");
 
-    const unsub = () => {
-      sub.close();
-      this.relay.close();
-    };
+          const unsub = () => {
+            sub.close();
+            this.relay.close();
+          };
 
-    sub.onevent = async (event) => {
-      const client = new NWCClient({
-        relayUrl: this.options.relayUrl,
-        secret: this.appSecretKey,
-        walletPubkey: event.pubkey,
-      });
+          sub.onevent = async (event) => {
+            const client = new NWCClient({
+              relayUrl: this.options.relayUrl,
+              secret: this.appSecretKey,
+              walletPubkey: event.pubkey,
+            });
 
-      // try to fetch the lightning address
-      try {
-        const info = await client.getInfo();
-        client.options.lud16 = info.lud16;
-        client.lud16 = info.lud16;
-      } catch (error) {
-        console.error("failed to fetch get_info", error);
+            // try to fetch the lightning address
+            try {
+              const info = await client.getInfo();
+              client.options.lud16 = info.lud16;
+              client.lud16 = info.lud16;
+            } catch (error) {
+              console.error("failed to fetch get_info", error);
+            }
+
+            args.onSuccess(client);
+            unsub();
+          };
+
+          await new Promise<void>((resolve) => {
+            endPromise = () => {
+              resolve();
+            };
+            onRelayDisconnect = () => {
+              console.info("relay disconnected");
+              endPromise?.();
+            };
+            this.relay.onclose = onRelayDisconnect;
+          });
+          if (onRelayDisconnect !== undefined) {
+            this.relay.onclose = null;
+          }
+        } catch (error) {
+          console.error(
+            "error subscribing to notifications",
+            error || "unknown relay error",
+          );
+        }
+        if (subscribed) {
+          // wait a second and try re-connecting
+          // any notifications during this period will be lost
+          // unless using a relay that keeps events until client reconnect
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
       }
-
-      args.onSuccess(client);
-      unsub();
-    };
+    })();
 
     return {
-      unsub,
+      unsub: () => {
+        subscribed = false;
+        endPromise?.();
+        sub?.close();
+      },
     };
   }
 

--- a/src/NWAClient.ts
+++ b/src/NWAClient.ts
@@ -233,13 +233,13 @@ export class NWAClient {
           }
         } catch (error) {
           console.error(
-            "error subscribing to notifications",
+            "error subscribing to info event",
             error || "unknown relay error",
           );
         }
         if (subscribed) {
           // wait a second and try re-connecting
-          // any notifications during this period will be lost
+          // any events during this period will be lost
           // unless using a relay that keeps events until client reconnect
           await new Promise((resolve) => setTimeout(resolve, 1000));
         }

--- a/src/NWCClient.ts
+++ b/src/NWCClient.ts
@@ -881,6 +881,7 @@ export class NWCClient {
         if (subscribed) {
           // wait a second and try re-connecting
           // any notifications during this period will be lost
+          // unless using a relay that keeps events until client reconnect
           await new Promise((resolve) => setTimeout(resolve, 1000));
         }
       }


### PR DESCRIPTION
Code is copied from NWCClient `subscribeNotifications` (which seems to be working well there). In this case I think it's more complicated to try extracting the duplicated code, maybe we can revisit this if we have a third case where we subscribe like this.

Tested with Zappy Bird on iOS, plus locally with shutting down and restarting local relay