### PR TITLE
chore: add recipient_data to tx metadata

### DIFF
--- a/src/nwc/types.ts
+++ b/src/nwc/types.ts
@@ -161,6 +161,16 @@ export type Nip47Transaction = {
 };
 
 export type Nip47TransactionMetadata = {
+  success_action?:
+    | {
+        tag: "message";
+        message: string;
+      }
+    | {
+        tag: "url";
+        description: string;
+        url: string;
+      }; // LUD-09
   comment?: string; // LUD-12
   payer_data?: {
     email?: string;

--- a/src/nwc/types.ts
+++ b/src/nwc/types.ts
@@ -167,6 +167,9 @@ export type Nip47TransactionMetadata = {
     name?: string;
     pubkey?: string;
   }; // LUD-18
+  recipient_data?: {
+    identifier?: string;
+  }; // LUD-18
   nostr?: {
     pubkey: string;
     tags: string[][];

--- a/src/nwc/types.ts
+++ b/src/nwc/types.ts
@@ -161,16 +161,6 @@ export type Nip47Transaction = {
 };
 
 export type Nip47TransactionMetadata = {
-  success_action?:
-    | {
-        tag: "message";
-        message: string;
-      }
-    | {
-        tag: "url";
-        description: string;
-        url: string;
-      }; // LUD-09
   comment?: string; // LUD-12
   payer_data?: {
     email?: string;


### PR DESCRIPTION
Only adds identifier as description is not widely used and is usually the same message everytime (ex: "Sats for Adithya Vardhan")