### PR TITLE
feat(examples/nwc): rewrite lookup-invoice in typescript

### DIFF
--- a/examples/nwc/lookup-invoice.ts
+++ b/examples/nwc/lookup-invoice.ts
@@ -3,7 +3,7 @@ import "websocket-polyfill"; // required in node.js
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 
-import { webln as providers } from "../../dist/index.module.js";
+import { webln as providers } from "@getalby/sdk";
 
 const rl = readline.createInterface({ input, output });
 


### PR DESCRIPTION
this rewrites `lookup-invoice.js` found in examples/nwc in typescript as suggested here https://github.com/getAlby/js-sdk/pull/375