### PR TITLE
Convert the sign-message example to Typescript 

### DIFF
--- a/examples/nwc/sign-message.ts
+++ b/examples/nwc/sign-message.ts
@@ -3,7 +3,7 @@ import "websocket-polyfill"; // required in node.js
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 
-import { webln as providers } from "../../dist/index.module.js";
+import { NostrWebLNProvider } from "@getalby/sdk/webln";
 
 const rl = readline.createInterface({ input, output });
 
@@ -13,7 +13,7 @@ const nwcUrl =
 
 rl.close();
 
-const webln = new providers.NostrWebLNProvider({
+const webln = new NostrWebLNProvider({
   nostrWalletConnectUrl: nwcUrl,
 });
 await webln.enable();


### PR DESCRIPTION
this rewrites `sign-message.js` found in examples/nwc to typescript as suggested here https://github.com/getAlby/js-sdk/pull/375#issuecomment-2840728478