### PR TITLE
fix(query): improve buildQueryString for nested params and update GetInvoicesRequestParams

### DIFF
--- a/src/oauth/types.ts
+++ b/src/oauth/types.ts
@@ -93,8 +93,9 @@ export type ExtractAlbyResponse<T> = "responses" extends keyof T
 export type GetInvoicesRequestParams = {
   q?: {
     since?: string;
-    created_at_lt?: string;
-    created_at_gt?: string;
+    before?: string;
+    created_at_lt?: number;
+    created_at_gt?: number;
   };
   page?: number;
   items?: number;

--- a/src/oauth/utils.ts
+++ b/src/oauth/utils.ts
@@ -1,4 +1,5 @@
-// https://stackoverflow.com/a/62969380 + fix to remove empty entries (.filter(entry => entry)) + fix to map nested objects well
+// https://stackoverflow.com/a/62969380 + fix to remove empty entries (.filter(entry => entry))
+// also maps nested objects e.g. {q: {since: 123}} will become ?q[since]=123
 export function buildQueryString(query: Record<string, unknown>): string {
   const build = (obj: Record<string, unknown>, prefix?: string): string[] => {
     return Object.entries(obj).flatMap(([key, value]) => {

--- a/src/oauth/utils.ts
+++ b/src/oauth/utils.ts
@@ -1,11 +1,19 @@
-// https://stackoverflow.com/a/62969380 + fix to remove empty entries (.filter(entry => entry))
+// https://stackoverflow.com/a/62969380 + fix to remove empty entries (.filter(entry => entry)) + fix to map nested objects well
 export function buildQueryString(query: Record<string, unknown>): string {
-  return Object.entries(query)
-    .map(([key, value]) => (key && value ? `${key}=${value}` : ""))
-    .filter((entry) => entry)
-    .join("&");
-}
+  const build = (obj: Record<string, unknown>, prefix?: string): string[] => {
+    return Object.entries(obj).flatMap(([key, value]) => {
+      const paramKey = prefix ? `${prefix}[${key}]` : key;
 
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        return build(value as Record<string, unknown>, paramKey);
+      }
+
+      return value !== undefined && value !== null ? `${paramKey}=${value}` : [];
+    });
+  };
+
+  return build(query).join("&");
+}
 export function basicAuthHeader(
   client_id: string,
   client_secret: string | undefined,


### PR DESCRIPTION

### **PR Description**

This PR fixes issue #474 with query parameter handling in invoice requests: 

* **Updated `buildQueryString`**

  * Added support for nested objects (e.g. `q[created_at_gt]`) so they no longer serialize as `[object Object]`.
  * Dropped empty/null/undefined entries to prevent stray `&&` in query strings.

* **Updated `GetInvoicesRequestParams` type**

  * Added support for `q.before` (invoice ID pagination).
  * Changed `created_at_lt` / `created_at_gt` from `string` to `number` to correctly match the type expected in the docs.


