### PR TITLE
chore: log connection error when failing to reconnect to relay

### DIFF
--- a/src/nwc/NWCClient.ts
+++ b/src/nwc/NWCClient.ts
@@ -1102,10 +1102,13 @@ export class NWCClient {
       if (!this.relay.connected) {
         await this.relay.connect();
       }
-    } catch (_ /* error is always undefined */) {
-      console.error("failed to connect to relay", this.relayUrl);
+    } catch (error) {
+      console.error("failed to connect to relay", {
+        url: this.relayUrl,
+        error,
+      });
       throw new Nip47NetworkError(
-        "Failed to connect to " + this.relayUrl,
+        "Failed to connect to " + this.relayUrl + ": " + error,
         "OTHER",
       );
     }


### PR DESCRIPTION
I noticed one of my apps was never able to reconnect even though the relay was working fine. It kept logging `failed to connect to relay wss://relay.getalby.com/v1`. Still needs to be debugged what went wrong.