### PR TITLE
refactor: remove websocket-polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,8 @@ The [Alby OAuth API](https://guides.getalby.com/alby-wallet-api/reference/gettin
 
 **This library relies on a global fetch() function which will work in browsers and node v18.x or newer.** (In older versions you have to use a polyfill.)
 
-#### Websocket polyfill
-
-To use this on Node.js you first must install `websocket-polyfill@0.0.3` and import it:
-
-```js
-import "websocket-polyfill";
-// or: require('websocket-polyfill');
-```
+#### WebSocket Polyfill
+If you are using Node.js < v22, you may need a WebSocket polyfill. We recommend `websocket-polyfill` but checking your node version is preferred.
 
 ## WebLN Documentation
 

--- a/docs/lnclient.md
+++ b/docs/lnclient.md
@@ -35,12 +35,7 @@ See [the LNClient examples directory](./examples/lnclient) for a full list of ex
 
 ## For Node.js
 
-To use this on Node.js you first must install `websocket-polyfill@0.0.3` and import it:
 
-```js
-import "websocket-polyfill";
-// or: require('websocket-polyfill');
-```
 
 if you get an `crypto is not defined` error, either upgrade to node.js 20 or above, or import it manually:
 

--- a/docs/nwc.md
+++ b/docs/nwc.md
@@ -153,12 +153,7 @@ Look at our [NWC React Native Expo Demo app](https://github.com/getAlby/nwc-reac
 
 #### For Node.js
 
-To use this on Node.js you first must install `websocket-polyfill@0.0.3` and import it:
 
-```js
-import "websocket-polyfill";
-// or: require('websocket-polyfill');
-```
 
 if you get an `crypto is not defined` error, either upgrade to node.js 20 or above, or import it manually:
 

--- a/examples/lnclient/pay_ln_address.ts
+++ b/examples/lnclient/pay_ln_address.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/lnclient/paywall.ts
+++ b/examples/lnclient/paywall.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 import qrcode from "qrcode-terminal";
 
 import * as readline from "node:readline/promises";

--- a/examples/lnclient/splitter.ts
+++ b/examples/lnclient/splitter.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 import qrcode from "qrcode-terminal";
 
 import * as readline from "node:readline/promises";

--- a/examples/nwc/client/create-connection.ts
+++ b/examples/nwc/client/create-connection.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/client/get-balance.ts
+++ b/examples/nwc/client/get-balance.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/client/get-budget.ts
+++ b/examples/nwc/client/get-budget.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/client/get-info.ts
+++ b/examples/nwc/client/get-info.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/client/get-wallet-service-info.ts
+++ b/examples/nwc/client/get-wallet-service-info.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/client/hold-invoice.ts
+++ b/examples/nwc/client/hold-invoice.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/client/list-transactions.ts
+++ b/examples/nwc/client/list-transactions.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/client/lookup-invoice.ts
+++ b/examples/nwc/client/lookup-invoice.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/client/make-invoice.ts
+++ b/examples/nwc/client/make-invoice.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/client/multi-pay-invoice.ts
+++ b/examples/nwc/client/multi-pay-invoice.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import { LightningAddress } from "@getalby/lightning-tools";
 

--- a/examples/nwc/client/multi-pay-keysend.ts
+++ b/examples/nwc/client/multi-pay-keysend.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/client/nwa-accept.ts
+++ b/examples/nwc/client/nwa-accept.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/client/nwa.ts
+++ b/examples/nwc/client/nwa.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 import qrcode from "qrcode-terminal";
 
 import * as readline from "node:readline/promises";

--- a/examples/nwc/client/pay-invoice.ts
+++ b/examples/nwc/client/pay-invoice.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/client/pay-keysend.ts
+++ b/examples/nwc/client/pay-keysend.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/client/sign-message.ts
+++ b/examples/nwc/client/sign-message.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/client/subscribe.ts
+++ b/examples/nwc/client/subscribe.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/client/wrapped-invoice.ts
+++ b/examples/nwc/client/wrapped-invoice.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/get-balance.ts
+++ b/examples/nwc/get-balance.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/get-info.ts
+++ b/examples/nwc/get-info.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/keysend.ts
+++ b/examples/nwc/keysend.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/list-transactions.ts
+++ b/examples/nwc/list-transactions.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/lookup-invoice.ts
+++ b/examples/nwc/lookup-invoice.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/make-invoice.ts
+++ b/examples/nwc/make-invoice.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/multi-keysend.ts
+++ b/examples/nwc/multi-keysend.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/send-multi-payment.ts
+++ b/examples/nwc/send-multi-payment.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import { LightningAddress } from "@getalby/lightning-tools";
 

--- a/examples/nwc/send-payment.ts
+++ b/examples/nwc/send-payment.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/sign-message.ts
+++ b/examples/nwc/sign-message.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";

--- a/examples/nwc/wallet-service/example.ts
+++ b/examples/nwc/wallet-service/example.ts
@@ -1,4 +1,3 @@
-import "websocket-polyfill"; // required in node.js
 
 import { generateSecretKey, getPublicKey } from "nostr-tools";
 import { bytesToHex, hexToBytes } from "@noble/hashes/utils";

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,8 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
-module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
+export default {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.tsx?$": ["ts-jest", { useESM: true }],
+  },
 };

--- a/package.json
+++ b/package.json
@@ -89,8 +89,7 @@
     "ts-jest": "^29.4.1",
     "ts-node": "^10.9.1",
     "tslib": "^2.8.1",
-    "typescript": "^5.1.6",
-    "websocket-polyfill": "^0.0.3"
+    "typescript": "^5.1.6"
   },
   "engines": {
     "node": ">=14"

--- a/src/nwc/NWAClient.test.ts
+++ b/src/nwc/NWAClient.test.ts
@@ -1,4 +1,4 @@
-import "websocket-polyfill";
+
 import { NWAClient } from "./NWAClient";
 import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
 import { generateSecretKey, getPublicKey } from "nostr-tools";

--- a/src/nwc/NWAClient.ts
+++ b/src/nwc/NWAClient.ts
@@ -51,8 +51,8 @@ export class NWAClient {
     this.pool = new SimplePool();
 
     if (globalThis.WebSocket === undefined) {
-      console.error(
-        "WebSocket is undefined. Make sure to `import websocket-polyfill` for nodejs environments",
+      throw new Error(
+        "WebSocket is undefined. Make sure to polyfill it for nodejs environments",
       );
     }
   }

--- a/src/nwc/NWAClient.ts
+++ b/src/nwc/NWAClient.ts
@@ -7,7 +7,7 @@ import {
   Nip47NotificationType,
 } from "./types";
 import { NWCClient } from "./NWCClient";
-import { SubCloser } from "nostr-tools/lib/types/abstract-pool";
+import { SubCloser } from "nostr-tools/abstract-pool";
 
 export type NWAOptions = {
   relayUrls: string[];

--- a/src/nwc/NWCClient.test.ts
+++ b/src/nwc/NWCClient.test.ts
@@ -1,4 +1,4 @@
-import "websocket-polyfill";
+
 import { NWCClient } from "./NWCClient";
 
 // this has no funds on it, I think ;-)

--- a/src/nwc/NWCClient.ts
+++ b/src/nwc/NWCClient.ts
@@ -141,8 +141,8 @@ export class NWCClient {
     // this.subscribers = {};
 
     if (globalThis.WebSocket === undefined) {
-      console.error(
-        "WebSocket is undefined. Make sure to `import websocket-polyfill` for nodejs environments",
+      throw new Error(
+        "WebSocket is undefined. Make sure to polyfill it for nodejs environments",
       );
     }
   }

--- a/src/nwc/NWCWalletService.ts
+++ b/src/nwc/NWCWalletService.ts
@@ -60,8 +60,8 @@ export class NWCWalletService {
     this.relay = new Relay(this.relayUrl);
 
     if (globalThis.WebSocket === undefined) {
-      console.error(
-        "WebSocket is undefined. Make sure to `import websocket-polyfill` for nodejs environments",
+      throw new Error(
+        "WebSocket is undefined. Make sure to polyfill it for nodejs environments",
       );
     }
   }

--- a/src/nwc/NWCWalletService.ts
+++ b/src/nwc/NWCWalletService.ts
@@ -8,7 +8,7 @@ import {
   Relay,
 } from "nostr-tools";
 import { hexToBytes } from "@noble/hashes/utils";
-import { Subscription } from "nostr-tools/lib/types/abstract-relay";
+import { Subscription } from "nostr-tools/abstract-relay";
 
 import {
   Nip47MakeInvoiceRequest,

--- a/src/oauth/AlbyResponseError.test.ts
+++ b/src/oauth/AlbyResponseError.test.ts
@@ -1,5 +1,5 @@
 import { AlbyResponseError } from "./AlbyResponseError";
-import "websocket-polyfill";
+
 
 describe("AlbyResponseError", () => {
   test("Error message is generated", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "lib": ["ES2021", "DOM"],
     "target": "es2020",
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2047,13 +2047,6 @@ buffer-from@^1.0.0:
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-bufferutil@^4.0.1:
-  version "4.0.7"
-  resolved "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz"
-  integrity sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==
-  dependencies:
-    node-gyp-build "^4.3.0"
-
 bytes@3.1.2, bytes@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz"
@@ -2315,25 +2308,10 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-d@1, d@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/d/-/d-1.0.1.tgz"
-  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
-  dependencies:
-    es5-ext "^0.10.50"
-    type "^1.0.1"
-
 dargs@^8.0.0:
   version "8.1.0"
   resolved "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz"
   integrity sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==
-
-debug@^2.2.0:
-  version "2.6.9"
-  resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
 
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0:
   version "4.4.0"
@@ -2481,33 +2459,6 @@ es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   dependencies:
     es-errors "^1.3.0"
 
-es5-ext@^0.10.35, es5-ext@^0.10.50, es5-ext@^0.10.62, es5-ext@~0.10.14:
-  version "0.10.64"
-  resolved "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz"
-  integrity sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==
-  dependencies:
-    es6-iterator "^2.0.3"
-    es6-symbol "^3.1.3"
-    esniff "^2.0.1"
-    next-tick "^1.1.0"
-
-es6-iterator@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz"
-  integrity sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
-
-es6-symbol@^3.1.1, es6-symbol@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz"
-  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
-  dependencies:
-    d "^1.0.1"
-    ext "^1.1.2"
-
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz"
@@ -2600,16 +2551,6 @@ eslint@^8.46.0:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-esniff@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz"
-  integrity sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==
-  dependencies:
-    d "^1.0.1"
-    es5-ext "^0.10.62"
-    event-emitter "^0.3.5"
-    type "^2.7.2"
-
 espree@^9.6.0, espree@^9.6.1:
   version "9.6.1"
   resolved "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz"
@@ -2657,14 +2598,6 @@ etag@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
-
-event-emitter@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
-  integrity sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
 
 eventemitter3@^5.0.1:
   version "5.0.1"
@@ -2747,13 +2680,6 @@ express@^5.1.0:
     statuses "^2.0.1"
     type-is "^2.0.1"
     vary "^1.1.2"
-
-ext@^1.1.2:
-  version "1.7.0"
-  resolved "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz"
-  integrity sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==
-  dependencies:
-    type "^2.7.2"
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -3249,11 +3175,6 @@ is-text-path@^2.0.0:
   integrity sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==
   dependencies:
     text-extensions "^2.0.0"
-
-is-typedarray@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-  integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -4053,11 +3974,6 @@ minimist@^1.2.5, minimist@^1.2.8:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
-
 ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
@@ -4087,16 +4003,6 @@ neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
-
-next-tick@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz"
-  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
-
-node-gyp-build@^4.3.0:
-  version "4.6.0"
-  resolved "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz"
-  integrity sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -4959,11 +4865,6 @@ tslib@^2.4.0, tslib@^2.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
-tstl@^2.0.7:
-  version "2.5.13"
-  resolved "https://registry.npmjs.org/tstl/-/tstl-2.5.13.tgz"
-  integrity sha512-h9wayHHFI5+yqt8iau0vqH96cTNhezhZ/Fk/hrIdpfkiMu3lg9nzyvMfs5bIdX51IVzZO6DudLqhkL/rVXpT6g==
-
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz"
@@ -4999,23 +4900,6 @@ type-is@^2.0.0, type-is@^2.0.1:
     content-type "^1.0.5"
     media-typer "^1.1.0"
     mime-types "^3.0.0"
-
-type@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/type/-/type-1.2.0.tgz"
-  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
-
-type@^2.7.2:
-  version "2.7.2"
-  resolved "https://registry.npmjs.org/type/-/type-2.7.2.tgz"
-  integrity sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==
-
-typedarray-to-buffer@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz"
-  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
-  dependencies:
-    is-typedarray "^1.0.0"
 
 typescript@^5.1.6:
   version "5.9.3"
@@ -5092,13 +4976,6 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-utf-8-validate@^5.0.2:
-  version "5.0.10"
-  resolved "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz"
-  integrity sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==
-  dependencies:
-    node-gyp-build "^4.3.0"
-
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz"
@@ -5124,26 +5001,6 @@ walker@^1.0.8:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
-
-websocket-polyfill@^0.0.3:
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/websocket-polyfill/-/websocket-polyfill-0.0.3.tgz"
-  integrity sha512-pF3kR8Uaoau78MpUmFfzbIRxXj9PeQrCuPepGE6JIsfsJ/o/iXr07Q2iQNzKSSblQJ0FiGWlS64N4pVSm+O3Dg==
-  dependencies:
-    tstl "^2.0.7"
-    websocket "^1.0.28"
-
-websocket@^1.0.28:
-  version "1.0.34"
-  resolved "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz"
-  integrity sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==
-  dependencies:
-    bufferutil "^4.0.1"
-    debug "^2.2.0"
-    es5-ext "^0.10.50"
-    typedarray-to-buffer "^3.1.5"
-    utf-8-validate "^5.0.2"
-    yaeti "^0.0.6"
 
 which@^2.0.1:
   version "2.0.2"
@@ -5210,11 +5067,6 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
-
-yaeti@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz"
-  integrity sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==
 
 yallist@^3.0.2:
   version "3.1.1"


### PR DESCRIPTION
Closes #519

websocket-polyfill is only needed for NodeJS < 22, and it incorrectly overwrites WebSocket even if it already exists on the global object.

This PR:
- Removes websocket-polyfill dependency
- Removes imports from tests and examples
- Updates documentation to remove installation instructions
- Updates error messages to be generic for missing WebSocket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed websocket-polyfill dependency from the package.
  * Updated documentation to reflect polyfill removal and guidance for Node.js versions.
  * Updated Jest configuration for ES module support and module resolution settings.
  * Updated internal import paths for improved compatibility.

* **Bug Fixes**
  * Improved error handling for missing WebSocket support with clearer error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->