### PR TITLE
feat: replace console.debug with injectable logger interface

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,7 @@
       }
     ],
     "@typescript-eslint/no-unused-vars": ["warn", { "args": "none" }],
-    "no-console": ["error", { "allow": ["info", "warn", "error"] }],
+    "no-console": ["error", { "allow": ["debug", "warn", "error"] }],
     "no-constant-binary-expression": "error"
   },
   "globals": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,7 @@
       }
     ],
     "@typescript-eslint/no-unused-vars": ["warn", { "args": "none" }],
-    "no-console": ["error", { "allow": ["debug", "warn", "error"] }],
+    "no-console": ["error", { "allow": ["warn", "error"] }],
     "no-constant-binary-expression": "error"
   },
   "globals": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./logger";
 export * from "./oauth";
 export * from "./webln";
 export * from "./nwc";

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,7 @@
+export interface Logger {
+  debug(...args: unknown[]): void;
+}
+
+export const noopLogger: Logger = {
+  debug() {},
+};

--- a/src/nwc/NWAClient.ts
+++ b/src/nwc/NWAClient.ts
@@ -1,5 +1,6 @@
 import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
 import { generateSecretKey, getPublicKey, SimplePool } from "nostr-tools";
+import { Logger, noopLogger } from "../logger";
 import {
   BudgetRenewalPeriod,
   Nip47Method,
@@ -27,6 +28,7 @@ export type NWAOptions = {
 
 export type NewNWAClientOptions = Omit<NWAOptions, "appPubkey"> & {
   appSecretKey?: string;
+  logger?: Logger;
 };
 
 // TODO: add support for multiple relay URLs
@@ -34,6 +36,7 @@ export class NWAClient {
   options: NWAOptions;
   appSecretKey: string;
   pool: SimplePool;
+  logger: Logger;
 
   constructor(options: NewNWAClientOptions) {
     this.appSecretKey = options.appSecretKey || bytesToHex(generateSecretKey());
@@ -49,6 +52,7 @@ export class NWAClient {
       throw new Error("Missing request methods");
     }
     this.pool = new SimplePool();
+    this.logger = options.logger || noopLogger;
 
     if (globalThis.WebSocket === undefined) {
       console.error(
@@ -215,12 +219,12 @@ export class NWAClient {
               onclose: (reasons) => {
                 // NOTE: this fires when all relays were closed once. There is no reconnect logic in nostr-tools
                 // See https://github.com/nbd-wtf/nostr-tools/issues/513
-                console.debug("relay connection closed", reasons);
+                this.logger.debug("relay connection closed", reasons);
                 endPromise?.();
               },
             },
           );
-          console.debug("subscribed to relays");
+          this.logger.debug("subscribed to relays");
 
           await new Promise<void>((resolve) => {
             endPromise = () => {

--- a/src/nwc/NWAClient.ts
+++ b/src/nwc/NWAClient.ts
@@ -215,12 +215,12 @@ export class NWAClient {
               onclose: (reasons) => {
                 // NOTE: this fires when all relays were closed once. There is no reconnect logic in nostr-tools
                 // See https://github.com/nbd-wtf/nostr-tools/issues/513
-                console.info("relay connection closed", reasons);
+                console.debug("relay connection closed", reasons);
                 endPromise?.();
               },
             },
           );
-          console.info("subscribed to relays");
+          console.debug("subscribed to relays");
 
           await new Promise<void>((resolve) => {
             endPromise = () => {

--- a/src/nwc/NWAClient.ts
+++ b/src/nwc/NWAClient.ts
@@ -199,6 +199,7 @@ export class NWAClient {
                   relayUrls: this.options.relayUrls,
                   secret: this.appSecretKey,
                   walletPubkey: event.pubkey,
+                  logger: this.logger,
                 });
 
                 // try to fetch the lightning address

--- a/src/nwc/NWCClient.ts
+++ b/src/nwc/NWCClient.ts
@@ -11,6 +11,7 @@ import {
   SimplePool,
 } from "nostr-tools";
 import { hexToBytes, bytesToHex } from "@noble/hashes/utils";
+import { Logger, noopLogger } from "../logger";
 import {
   Nip47EncryptionType,
   Nip47SingleMethod,
@@ -70,6 +71,7 @@ export type NewNWCClientOptions = {
   walletPubkey?: string;
   nostrWalletConnectUrl?: string;
   lud16?: string;
+  logger?: Logger;
 };
 
 export class NWCClient {
@@ -79,6 +81,7 @@ export class NWCClient {
   lud16: string | undefined;
   walletPubkey: string;
   options: NWCOptions;
+  logger: Logger;
   private _encryptionType: Nip47EncryptionType | undefined;
 
   static parseWalletConnectUrl(walletConnectUrl: string): NWCOptions {
@@ -122,6 +125,7 @@ export class NWCClient {
     } as NWCOptions;
 
     this.relayUrls = this.options.relayUrls;
+    this.logger = options?.logger || noopLogger;
     this.pool = new SimplePool({});
     if (this.options.secret) {
       this.secret = (
@@ -717,7 +721,7 @@ export class NWCClient {
         try {
           await this._checkConnected();
           await this._selectEncryptionType();
-          console.debug("subscribing to relays");
+          this.logger.debug("subscribing to relays");
           sub = this.pool.subscribe(
             this.relayUrls,
             {
@@ -764,12 +768,12 @@ export class NWCClient {
               onclose: (reasons) => {
                 // NOTE: this fires when all relays were closed once. There is no reconnect logic in nostr-tools
                 // See https://github.com/nbd-wtf/nostr-tools/issues/513
-                console.debug("relay connection closed", reasons);
+                this.logger.debug("relay connection closed", reasons);
                 endPromise?.();
               },
             },
           );
-          console.debug("subscribed to relays");
+          this.logger.debug("subscribed to relays");
 
           await new Promise<void>((resolve) => {
             endPromise = () => {
@@ -864,7 +868,6 @@ export class NWCClient {
                 return;
               }
               if (response.result) {
-                // console.debug("NIP-47 result", response.result);
                 if (resultValidator(response.result)) {
                   resolve(response.result);
                 } else {
@@ -927,9 +930,7 @@ export class NWCClient {
         try {
           await Promise.any(this.pool.publish(this.relayUrls, event));
           clearTimeout(publishTimeoutCheck);
-          //console.debug(`Event ${event.id} for ${invoice} published`);
         } catch (error) {
-          //console.error(`Failed to publish to ${this.relay.url}`, error);
           clearTimeout(publishTimeoutCheck);
           reject(
             new Nip47PublishError(`failed to publish: ${error}`, "INTERNAL"),
@@ -1008,7 +1009,6 @@ export class NWCClient {
                 );
               }
               if (response.result) {
-                // console.debug("NIP-47 result", response.result);
                 if (!resultValidator(response.result)) {
                   clearTimeout(replyTimeoutCheck);
                   sub.close();
@@ -1091,9 +1091,7 @@ export class NWCClient {
         try {
           await Promise.any(this.pool.publish(this.relayUrls, event));
           clearTimeout(publishTimeoutCheck);
-          //console.debug(`Event ${event.id} for ${invoice} published`);
         } catch (error) {
-          //console.error(`Failed to publish to ${this.relay.url}`, error);
           clearTimeout(publishTimeoutCheck);
           reject(
             new Nip47PublishError(`Failed to publish: ${error}`, "INTERNAL"),

--- a/src/nwc/NWCClient.ts
+++ b/src/nwc/NWCClient.ts
@@ -122,8 +122,7 @@ export class NWCClient {
     } as NWCOptions;
 
     this.relayUrls = this.options.relayUrls;
-    this.pool = new SimplePool({
-    });
+    this.pool = new SimplePool({});
     if (this.options.secret) {
       this.secret = (
         this.options.secret.toLowerCase().startsWith("nsec")
@@ -718,7 +717,7 @@ export class NWCClient {
         try {
           await this._checkConnected();
           await this._selectEncryptionType();
-          console.info("subscribing to relays");
+          console.debug("subscribing to relays");
           sub = this.pool.subscribe(
             this.relayUrls,
             {
@@ -765,12 +764,12 @@ export class NWCClient {
               onclose: (reasons) => {
                 // NOTE: this fires when all relays were closed once. There is no reconnect logic in nostr-tools
                 // See https://github.com/nbd-wtf/nostr-tools/issues/513
-                console.info("relay connection closed", reasons);
+                console.debug("relay connection closed", reasons);
                 endPromise?.();
               },
             },
           );
-          console.info("subscribed to relays");
+          console.debug("subscribed to relays");
 
           await new Promise<void>((resolve) => {
             endPromise = () => {
@@ -865,7 +864,7 @@ export class NWCClient {
                 return;
               }
               if (response.result) {
-                // console.info("NIP-47 result", response.result);
+                // console.debug("NIP-47 result", response.result);
                 if (resultValidator(response.result)) {
                   resolve(response.result);
                 } else {
@@ -1009,7 +1008,7 @@ export class NWCClient {
                 );
               }
               if (response.result) {
-                // console.info("NIP-47 result", response.result);
+                // console.debug("NIP-47 result", response.result);
                 if (!resultValidator(response.result)) {
                   clearTimeout(replyTimeoutCheck);
                   sub.close();

--- a/src/nwc/NWCWalletService.ts
+++ b/src/nwc/NWCWalletService.ts
@@ -102,9 +102,9 @@ export class NWCWalletService {
     (async () => {
       while (subscribed) {
         try {
-          console.info("checking connection to relay");
+          console.debug("checking connection to relay");
           await this._checkConnected();
-          console.info("subscribing to relay");
+          console.debug("subscribing to relay");
           sub = this.relay.subscribe(
             [
               {
@@ -115,11 +115,11 @@ export class NWCWalletService {
             ],
             {},
           );
-          console.info("subscribed to relays");
+          console.debug("subscribed to relays");
 
           sub.onevent = async (event) => {
             try {
-              // console.info("Got event", event);
+              // console.debug("Got event", event);
               const encryptionType = (event.tags.find(
                 (t) => t[0] === "encryption",
               )?.[1] || "nip04") as Nip47EncryptionType;
@@ -271,7 +271,7 @@ export class NWCWalletService {
     encryptionType: Nip47EncryptionType,
   ) {
     let encrypted;
-    // console.info("encrypting with" + encryptionType);
+    // console.debug("encrypting with" + encryptionType);
     if (encryptionType === "nip04") {
       encrypted = await nip04.encrypt(
         keypair.walletSecret,
@@ -294,7 +294,7 @@ export class NWCWalletService {
     encryptionType: Nip47EncryptionType,
   ) {
     let decrypted;
-    // console.info("decrypting with" + encryptionType);
+    // console.debug("decrypting with" + encryptionType);
     if (encryptionType === "nip04") {
       decrypted = await nip04.decrypt(
         keypair.walletSecret,

--- a/src/nwc/NWCWalletService.ts
+++ b/src/nwc/NWCWalletService.ts
@@ -10,6 +10,7 @@ import {
 import { hexToBytes } from "@noble/hashes/utils";
 import { Subscription } from "nostr-tools/lib/types/abstract-relay";
 
+import { Logger, noopLogger } from "../logger";
 import {
   Nip47MakeInvoiceRequest,
   Nip47Method,
@@ -31,6 +32,7 @@ import {
 
 export type NewNWCWalletServiceOptions = {
   relayUrl: string;
+  logger?: Logger;
 };
 
 export class NWCWalletServiceKeyPair {
@@ -53,9 +55,11 @@ export class NWCWalletServiceKeyPair {
 export class NWCWalletService {
   relay: Relay;
   relayUrl: string;
+  logger: Logger;
 
   constructor(options: NewNWCWalletServiceOptions) {
     this.relayUrl = options.relayUrl;
+    this.logger = options.logger || noopLogger;
 
     this.relay = new Relay(this.relayUrl);
 
@@ -102,9 +106,9 @@ export class NWCWalletService {
     (async () => {
       while (subscribed) {
         try {
-          console.debug("checking connection to relay");
+          this.logger.debug("checking connection to relay");
           await this._checkConnected();
-          console.debug("subscribing to relay");
+          this.logger.debug("subscribing to relay");
           sub = this.relay.subscribe(
             [
               {
@@ -115,11 +119,10 @@ export class NWCWalletService {
             ],
             {},
           );
-          console.debug("subscribed to relays");
+          this.logger.debug("subscribed to relays");
 
           sub.onevent = async (event) => {
             try {
-              // console.debug("Got event", event);
               const encryptionType = (event.tags.find(
                 (t) => t[0] === "encryption",
               )?.[1] || "nip04") as Nip47EncryptionType;
@@ -271,7 +274,6 @@ export class NWCWalletService {
     encryptionType: Nip47EncryptionType,
   ) {
     let encrypted;
-    // console.debug("encrypting with" + encryptionType);
     if (encryptionType === "nip04") {
       encrypted = await nip04.encrypt(
         keypair.walletSecret,
@@ -294,7 +296,6 @@ export class NWCWalletService {
     encryptionType: Nip47EncryptionType,
   ) {
     let decrypted;
-    // console.debug("decrypting with" + encryptionType);
     if (encryptionType === "nip04") {
       decrypted = await nip04.decrypt(
         keypair.walletSecret,

--- a/src/webln/OauthWeblnProvider.ts
+++ b/src/webln/OauthWeblnProvider.ts
@@ -149,7 +149,7 @@ export class OauthWeblnProvider {
           !processingCode
         ) {
           processingCode = true; // make sure we request the access token only once
-          console.info("Processing OAuth code response");
+          console.debug("Processing OAuth code response");
           const code = data.payload.code;
           try {
             await this.auth.requestAccessToken(code);

--- a/src/webln/OauthWeblnProvider.ts
+++ b/src/webln/OauthWeblnProvider.ts
@@ -1,4 +1,5 @@
 import { Client } from "../oauth/client";
+import { Logger, noopLogger } from "../logger";
 import { OAuthClient, KeysendRequestParams } from "../oauth/types";
 
 export interface RequestInvoiceArgs {
@@ -15,13 +16,15 @@ export class OauthWeblnProvider {
   oauth: boolean;
   subscribers: Record<string, (payload: unknown) => void>;
   isExecuting: boolean;
+  logger: Logger;
 
-  constructor(options: { auth: OAuthClient }) {
+  constructor(options: { auth: OAuthClient; logger?: Logger }) {
     this.auth = options.auth;
     this.client = new Client(options.auth);
     this.oauth = true;
     this.subscribers = {};
     this.isExecuting = false;
+    this.logger = options.logger || noopLogger;
   }
 
   on(name: string, callback: () => void) {
@@ -149,7 +152,7 @@ export class OauthWeblnProvider {
           !processingCode
         ) {
           processingCode = true; // make sure we request the access token only once
-          console.debug("Processing OAuth code response");
+          this.logger.debug("Processing OAuth code response");
           const code = data.payload.code;
           try {
             await this.auth.requestAccessToken(code);


### PR DESCRIPTION
## Summary
- Introduce a `Logger` interface (`src/logger.ts`) with a noop default, exported from the package root
- Remove `"debug"` from the ESLint `no-console` allow list so `console.debug` is now a lint error
- Add optional `logger` to `NWCClient`, `NWAClient`, `NWCWalletService`, and `OauthWeblnProvider` options — defaults to silent noop, consumers can pass `{ logger: console }` to opt in
- Clean up all commented-out `console.debug` lines

## Test plan
- [x] ESLint passes with no errors
- [x] TypeScript compiles with no errors
- [x] Pre-commit hooks (lint-staged, commitlint) pass
- [ ] Verify existing tests still pass (`yarn test`)
- [ ] Smoke-test with `{ logger: console }` to confirm debug output appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public, configurable Logger interface and a no-op default logger.
  * Made logging injectable across clients, wallet service, and OAuth provider; lifecycle events now use the configurable logger.
  * Exposed logger exports from the package entry point.

* **Chores**
  * Tightened linting to disallow certain console usage (console.info removed from allowed methods).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->