### PR TITLE
feat(#540): replaced references to nwc.getalby.com

### DIFF
--- a/src/nwc/NWCClient.test.ts
+++ b/src/nwc/NWCClient.test.ts
@@ -73,7 +73,7 @@ describe("getAuthorizationUrl", () => {
 
     expect(
       NWCClient.getAuthorizationUrl(
-        "https://nwc.getalby.com/apps/new",
+        "https://my.albyhub.com/apps/new",
         {
           budgetRenewal: "weekly",
           expiresAt: new Date("2023-07-21"),
@@ -88,7 +88,7 @@ describe("getAuthorizationUrl", () => {
         pubkey,
       ).toString(),
     ).toEqual(
-      `https://nwc.getalby.com/apps/new?name=TestApp&pubkey=${pubkey}&return_to=https%3A%2F%2Fexample.com&budget_renewal=weekly&expires_at=1689897600&max_amount=100&request_methods=pay_invoice+get_balance&notification_types=payment_received+payment_sent&isolated=true&metadata=%7B%22message%22%3A%22hello+world%22%7D`,
+      `https://my.albyhub.com/apps/new?name=TestApp&pubkey=${pubkey}&return_to=https%3A%2F%2Fexample.com&budget_renewal=weekly&expires_at=1689897600&max_amount=100&request_methods=pay_invoice+get_balance&notification_types=payment_received+payment_sent&isolated=true&metadata=%7B%22message%22%3A%22hello+world%22%7D`,
     );
   });
 


### PR DESCRIPTION
## Summary

Updates the `getAuthorizationUrl` unit test to use `https://my.albyhub.com/apps/new` instead of `https://nwc.getalby.com/apps/new`, which is no longer available.

## Context

The old NWC app URL host has been shut down. The SDK already documents and uses Alby Hub’s auth path elsewhere (examples, docs, JSDoc on `fromAuthorizationUrl` / `getAuthorizationUrl`).

Closes https://github.com/getAlby/js-sdk/issues/540

## Changes

- `src/nwc/NWCClient.test.ts`: swap the authorization base URL in the “standard url” test input and expected string to `my.albyhub.com`.

## Testing

```bash
yarn test src/nwc/NWCClient.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated authorization endpoint verification in test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->