### PR TITLE
fix(nwc): add p tag to NIP-47 response events

### DIFF
--- a/src/nwc/NWCWalletService.ts
+++ b/src/nwc/NWCWalletService.ts
@@ -196,7 +196,10 @@ export class NWCWalletService {
               const responseEventTemplate: EventTemplate = {
                 kind: 23195,
                 created_at: Math.floor(Date.now() / 1000),
-                tags: [["e", event.id]],
+                tags: [
+                  ["e", event.id],
+                  ["p", keypair.clientPubkey],
+                ],
                 content: await this.encrypt(
                   keypair,
                   JSON.stringify({


### PR DESCRIPTION
## Summary

Add the missing `p` tag to NIP-47 response events (`kind: 23195`).

Previously, wallet responses were published with only the request reference tag:

```ts
tags: [["e", event.id]]
```

This PR updates response events to include the client pubkey as well:

```ts
tags: [
  ["p", keypair.clientPubkey],
  ["e", event.id],
]
```

## Why

Some NIP-47 clients subscribe to wallet responses using `#p` filters:

```json
{
  "kinds": [23195],
  "#p": ["<client-pubkey>"]
}
```

Without the `p` tag, the relay does not forward the response event to those clients, even though the event is successfully published. This causes requests to eventually fail with a timeout.

Including both:

* `e` → request correlation
* `p` → recipient routing/filtering

improves interoperability with NIP-47 clients and aligns with the NIP-47 recommendation that response events SHOULD include a `p` tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Nostr Wallet Connect responses now include both the referenced request identifier and the client public key in response metadata, improving request correlation and tracking.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getAlby/js-sdk/pull/546)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->