### PR TITLE
fix: limit reconnecting pool known ids to 1000

### DIFF
--- a/src/nwc/ReconnectingPool.ts
+++ b/src/nwc/ReconnectingPool.ts
@@ -34,6 +34,10 @@ type SubscribeManyParams = {
 const INITIAL_RECONNECT_DELAY_MS = 1000;
 const MAX_RECONNECT_DELAY_MS = 5 * 60 * 1000;
 
+// Bounds the cross-relay/reconnect dedup window. Large enough to cover bursts
+// across reconnects, small enough that long-lived subscriptions don't leak.
+const MAX_KNOWN_IDS = 1000;
+
 export class ReconnectingPool {
   protected relays: Map<string, Relay> = new Map();
 
@@ -111,6 +115,10 @@ export class ReconnectingPool {
     const alreadyHaveEvent = (id: string) => {
       if (knownIds.has(id)) return true;
       knownIds.add(id);
+      if (knownIds.size > MAX_KNOWN_IDS) {
+        const oldest = knownIds.values().next().value;
+        if (oldest !== undefined) knownIds.delete(oldest);
+      }
       return false;
     };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized event deduplication to prevent unbounded memory growth in long-lived subscriptions. The deduplication mechanism now enforces a size limit and removes oldest entries when the threshold is exceeded, improving stability during extended operations and reconnect bursts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getAlby/js-sdk/pull/558)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->