### PR TITLE
feat: add recordEvent handler to NWCWalletService for request deduplication

### DIFF
--- a/e2e/nwc-wallet-service-record-event.test.ts
+++ b/e2e/nwc-wallet-service-record-event.test.ts
@@ -95,11 +95,7 @@ describe("NWCWalletService recordEvent", () => {
 
     try {
       // the wallet service should skip the request without responding,
-      // so the client's request should time out.
-      // NOTE: awaiting the timeout (rather than e.g. racing with a shorter
-      // one) also lets the client's subscription fully close - closing the
-      // client while a request is in flight leaves its reconnecting pool
-      // subscription running, which would keep the test process alive.
+      // so the client's request should time out
       await expect(client.getInfo()).rejects.toThrow("reply timeout");
       expect(recordedIds).toHaveLength(1);
       expect(getInfoCalls).toBe(0);

--- a/e2e/nwc-wallet-service-record-event.test.ts
+++ b/e2e/nwc-wallet-service-record-event.test.ts
@@ -1,0 +1,110 @@
+import { generateSecretKey, getPublicKey } from "nostr-tools";
+import { bytesToHex } from "@noble/hashes/utils.js";
+import { NWCClient } from "../src/nwc/NWCClient";
+import {
+  NWCWalletService,
+  NWCWalletServiceKeyPair,
+} from "../src/nwc/NWCWalletService";
+import { NWCWalletServiceRequestHandler } from "../src/nwc/NWCWalletServiceRequestHandler";
+import { Nip47GetInfoResponse } from "../src/nwc/types";
+
+/**
+ * E2E test for NWCWalletService recordEvent over a real relay.
+ * Requires network access.
+ */
+const RELAY_URL = "wss://relay.getalby.com/v1";
+
+const getInfoResult: Nip47GetInfoResponse = {
+  alias: "recordEvent e2e test",
+  color: "",
+  pubkey: "",
+  network: "bitcoin",
+  block_height: 0,
+  block_hash: "",
+  methods: ["get_info"],
+  notifications: [],
+};
+
+async function setupWalletServiceAndClient(
+  handler: NWCWalletServiceRequestHandler,
+) {
+  const walletSecret = bytesToHex(generateSecretKey());
+  const clientSecret = generateSecretKey();
+  const keypair = new NWCWalletServiceKeyPair(
+    walletSecret,
+    getPublicKey(clientSecret),
+  );
+
+  const service = new NWCWalletService({ relayUrls: [RELAY_URL] });
+  // the client requires the info event to negotiate the encryption type
+  await service.publishWalletServiceInfoEvent(walletSecret, ["get_info"], []);
+  const unsubscribe = await service.subscribe(keypair, handler);
+
+  const client = new NWCClient({
+    nostrWalletConnectUrl: `nostr+walletconnect://${
+      keypair.walletPubkey
+    }?relay=${encodeURIComponent(RELAY_URL)}&secret=${bytesToHex(
+      clientSecret,
+    )}`,
+  });
+
+  return {
+    client,
+    cleanup: () => {
+      client.close();
+      unsubscribe();
+      service.close();
+    },
+  };
+}
+
+describe("NWCWalletService recordEvent", () => {
+  test("records the request event id and handles the request", async () => {
+    const recordedIds: string[] = [];
+    const { client, cleanup } = await setupWalletServiceAndClient({
+      recordEvent: (eventId) => {
+        recordedIds.push(eventId);
+        return undefined;
+      },
+      getInfo: async () => ({ result: getInfoResult, error: undefined }),
+    });
+
+    try {
+      const info = await client.getInfo();
+      expect(info.alias).toBe(getInfoResult.alias);
+      expect(recordedIds).toHaveLength(1);
+      expect(recordedIds[0]).toMatch(/^[0-9a-f]{64}$/);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+
+  test("does not handle requests recorded as already processed", async () => {
+    const recordedIds: string[] = [];
+    let getInfoCalls = 0;
+    const { client, cleanup } = await setupWalletServiceAndClient({
+      recordEvent: (eventId) => {
+        recordedIds.push(eventId);
+        return "ALREADY_PROCESSED";
+      },
+      getInfo: async () => {
+        getInfoCalls++;
+        return { result: getInfoResult, error: undefined };
+      },
+    });
+
+    try {
+      // the wallet service should skip the request without responding,
+      // so the client's request should time out.
+      // NOTE: awaiting the timeout (rather than e.g. racing with a shorter
+      // one) also lets the client's subscription fully close - closing the
+      // client while a request is in flight leaves its reconnecting pool
+      // subscription running, which would keep the test process alive.
+      await expect(client.getInfo()).rejects.toThrow("reply timeout");
+      expect(recordedIds).toHaveLength(1);
+      expect(getInfoCalls).toBe(0);
+    } finally {
+      cleanup();
+    }
+  }, 30_000);
+});

--- a/src/nwc/NWCWalletService.test.ts
+++ b/src/nwc/NWCWalletService.test.ts
@@ -185,4 +185,23 @@ describe("response publishing", () => {
     await new Promise((resolve) => setTimeout(resolve, 1200));
     expect(publishCalls).toBe(1);
   }, 10_000);
+
+  test("stops retrying after the service is closed", async () => {
+    const { service, subscribeParams, requestEvent } =
+      await setupSubscribedWalletService({
+        getInfo: async () => getInfoResponse,
+      });
+
+    let publishCalls = 0;
+    service.pool.publish = () => {
+      publishCalls++;
+      return [Promise.reject(new Error("publish failed"))];
+    };
+
+    await subscribeParams.onevent(requestEvent);
+    service.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+    expect(publishCalls).toBe(1);
+  }, 10_000);
 });

--- a/src/nwc/NWCWalletService.test.ts
+++ b/src/nwc/NWCWalletService.test.ts
@@ -1,0 +1,188 @@
+import { generateSecretKey, getPublicKey, Event } from "nostr-tools";
+import { bytesToHex } from "@noble/hashes/utils.js";
+import { NWCWalletService, NWCWalletServiceKeyPair } from "./NWCWalletService";
+import { NWCWalletServiceRequestHandler } from "./NWCWalletServiceRequestHandler";
+import { Nip47GetInfoResponse } from "./types";
+
+type SubscribeParams = {
+  onevent: (event: Event) => Promise<void> | void;
+};
+
+async function setupSubscribedWalletService(
+  handler: NWCWalletServiceRequestHandler,
+) {
+  const walletSecret = bytesToHex(generateSecretKey());
+  const clientSecret = generateSecretKey();
+  const keypair = new NWCWalletServiceKeyPair(
+    walletSecret,
+    getPublicKey(clientSecret),
+  );
+
+  // the relay is never actually connected to: the pool is mocked below
+  const service = new NWCWalletService({
+    relayUrls: ["wss://relay.getalby.com/v1"],
+  });
+
+  let subscribeParams: SubscribeParams | undefined;
+  service.pool.subscribe = (_relayUrls, _filter, params) => {
+    subscribeParams = params as SubscribeParams;
+    return { close: () => {} } as ReturnType<typeof service.pool.subscribe>;
+  };
+  service.pool.publish = () => [Promise.resolve("")];
+  (
+    service as unknown as { _checkConnected: () => Promise<void> }
+  )._checkConnected = () => Promise.resolve();
+
+  const unsubscribe = await service.subscribe(keypair, handler);
+  if (!subscribeParams) {
+    throw new Error("subscribe was not called on the pool");
+  }
+
+  // a valid get_info request event as the client would publish it
+  const requestEvent = await service.signEvent(
+    {
+      kind: 23194,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [
+        ["p", keypair.walletPubkey],
+        ["encryption", "nip44_v2"],
+      ],
+      content: await service.encrypt(
+        keypair,
+        JSON.stringify({ method: "get_info", params: {} }),
+        "nip44_v2",
+      ),
+    },
+    bytesToHex(clientSecret),
+  );
+
+  return { service, subscribeParams, requestEvent, unsubscribe };
+}
+
+const getInfoResponse = {
+  result: {
+    alias: "test",
+    methods: ["get_info"],
+  } as Nip47GetInfoResponse,
+  error: undefined,
+};
+
+describe("recordEvent", () => {
+  test("handles the request when recordEvent does not skip it", async () => {
+    const recordedIds: string[] = [];
+    let getInfoCalls = 0;
+    const getInfo = async () => {
+      getInfoCalls++;
+      return getInfoResponse;
+    };
+    const { subscribeParams, requestEvent } =
+      await setupSubscribedWalletService({
+        recordEvent: (eventId) => {
+          recordedIds.push(eventId);
+          return undefined;
+        },
+        getInfo,
+      });
+
+    await subscribeParams.onevent(requestEvent);
+
+    expect(recordedIds).toEqual([requestEvent.id]);
+    expect(getInfoCalls).toBe(1);
+  });
+
+  test("skips events that were already processed", async () => {
+    let getInfoCalls = 0;
+    const getInfo = async () => {
+      getInfoCalls++;
+      return getInfoResponse;
+    };
+    const { subscribeParams, requestEvent } =
+      await setupSubscribedWalletService({
+        recordEvent: () => "ALREADY_PROCESSED",
+        getInfo,
+      });
+
+    await subscribeParams.onevent(requestEvent);
+
+    expect(getInfoCalls).toBe(0);
+  });
+
+  test("serializes recordEvent calls so concurrent duplicates cannot both pass", async () => {
+    const recordedIds: string[] = [];
+    let getInfoCalls = 0;
+    const getInfo = async () => {
+      getInfoCalls++;
+      return getInfoResponse;
+    };
+    const { subscribeParams, requestEvent } =
+      await setupSubscribedWalletService({
+        // an async check-then-record, as an app backed by a database would do.
+        // without serialization, two concurrent calls would both pass the check.
+        recordEvent: async (eventId) => {
+          const alreadyProcessed = recordedIds.includes(eventId);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          if (alreadyProcessed) {
+            return "ALREADY_PROCESSED";
+          }
+          recordedIds.push(eventId);
+          return undefined;
+        },
+        getInfo,
+      });
+
+    await Promise.all([
+      subscribeParams.onevent(requestEvent),
+      subscribeParams.onevent(requestEvent),
+    ]);
+
+    expect(getInfoCalls).toBe(1);
+  });
+});
+
+describe("response publishing", () => {
+  test("retries failed publishes with exponential backoff", async () => {
+    const { service, subscribeParams, requestEvent } =
+      await setupSubscribedWalletService({
+        getInfo: async () => getInfoResponse,
+      });
+
+    let publishCalls = 0;
+    service.pool.publish = () => {
+      publishCalls++;
+      return [
+        publishCalls < 2
+          ? Promise.reject(new Error("publish failed"))
+          : Promise.resolve(""),
+      ];
+    };
+
+    await subscribeParams.onevent(requestEvent);
+
+    // the first attempt happens immediately and fails
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(publishCalls).toBe(1);
+
+    // the second attempt happens after a 1s backoff and succeeds
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    expect(publishCalls).toBe(2);
+  }, 10_000);
+
+  test("stops retrying after unsubscribing", async () => {
+    const { service, subscribeParams, requestEvent, unsubscribe } =
+      await setupSubscribedWalletService({
+        getInfo: async () => getInfoResponse,
+      });
+
+    let publishCalls = 0;
+    service.pool.publish = () => {
+      publishCalls++;
+      return [Promise.reject(new Error("publish failed"))];
+    };
+
+    await subscribeParams.onevent(requestEvent);
+    unsubscribe();
+
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+    expect(publishCalls).toBe(1);
+  }, 10_000);
+});

--- a/src/nwc/NWCWalletService.ts
+++ b/src/nwc/NWCWalletService.ts
@@ -34,6 +34,10 @@ export type NewNWCWalletServiceOptions = {
   logger?: Logger;
 };
 
+// First retry waits 1s; each subsequent attempt doubles (1s, 2s, 4s, 8s, 16s).
+const INITIAL_PUBLISH_RETRY_DELAY_MS = 1000;
+const MAX_PUBLISH_ATTEMPTS = 6;
+
 export class NWCWalletServiceKeyPair {
   walletSecret: string;
   walletPubkey: string;
@@ -100,6 +104,13 @@ export class NWCWalletService {
     await this._checkConnected();
 
     this.logger.debug("subscribing to relays");
+
+    // serializes handler.recordEvent calls so duplicate events delivered in
+    // quick succession cannot pass the check concurrently
+    let recordEventQueue: Promise<unknown> = Promise.resolve();
+
+    let unsubscribed = false;
+
     const sub = this.pool.subscribe(
       this.relayUrls,
 
@@ -126,6 +137,18 @@ export class NWCWalletService {
               method: Nip47Method;
               params: unknown;
             };
+
+            if (handler.recordEvent) {
+              const recordEventPromise = recordEventQueue.then(() =>
+                handler.recordEvent?.(event.id),
+              );
+              // keep the queue alive even if recordEvent throws
+              recordEventQueue = recordEventPromise.catch(() => {});
+              if ((await recordEventPromise) === "ALREADY_PROCESSED") {
+                this.logger.debug("skipped already processed event", event.id);
+                return;
+              }
+            }
 
             let responsePromise:
               | NWCWalletServiceResponsePromise<unknown>
@@ -206,8 +229,9 @@ export class NWCWalletService {
               keypair.walletSecret,
             );
 
-            // Try to publish to at least one relay
-            Promise.any(this.pool.publish(this.relayUrls, responseEvent));
+            // Try to publish to at least one relay, retrying with
+            // exponential backoff until the subscription is closed
+            this._publishWithRetry(responseEvent, () => unsubscribed);
           } catch (e) {
             console.error("Failed to handle event", e);
             return;
@@ -223,8 +247,32 @@ export class NWCWalletService {
     );
 
     return () => {
+      unsubscribed = true;
       sub?.close();
     };
+  }
+
+  private async _publishWithRetry(event: Event, isStopped: () => boolean) {
+    for (let attempt = 0; attempt < MAX_PUBLISH_ATTEMPTS; attempt++) {
+      if (attempt > 0) {
+        const delay = INITIAL_PUBLISH_RETRY_DELAY_MS * 2 ** (attempt - 1);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+      if (isStopped()) {
+        return;
+      }
+      try {
+        // Try to publish to at least one relay
+        await Promise.any(this.pool.publish(this.relayUrls, event));
+        return;
+      } catch (error) {
+        console.error(
+          `failed to publish response event (attempt ${attempt + 1}/${MAX_PUBLISH_ATTEMPTS})`,
+          event.id,
+          error,
+        );
+      }
+    }
   }
 
   get connected() {

--- a/src/nwc/NWCWalletService.ts
+++ b/src/nwc/NWCWalletService.ts
@@ -230,7 +230,7 @@ export class NWCWalletService {
             );
 
             // Try to publish to at least one relay, retrying with
-            // exponential backoff until the subscription is closed
+            // exponential backoff (up to MAX_PUBLISH_ATTEMPTS times)
             this._publishWithRetry(responseEvent, () => unsubscribed);
           } catch (e) {
             console.error("Failed to handle event", e);
@@ -258,7 +258,7 @@ export class NWCWalletService {
         const delay = INITIAL_PUBLISH_RETRY_DELAY_MS * 2 ** (attempt - 1);
         await new Promise((resolve) => setTimeout(resolve, delay));
       }
-      if (isStopped()) {
+      if (isStopped() || this.pool.closed) {
         return;
       }
       try {

--- a/src/nwc/NWCWalletServiceRequestHandler.ts
+++ b/src/nwc/NWCWalletServiceRequestHandler.ts
@@ -37,6 +37,10 @@ export interface NWCWalletServiceRequestHandler {
    * e.g. if a relay re-delivers an event that was already processed.
    * Calls are serialized by the wallet service, so duplicates delivered in
    * quick succession will still be seen one at a time.
+   *
+   * Note this provides event-level deduplication, not payment idempotency:
+   * two events with different ids can still request payment of the same
+   * invoice, which must be handled at the wallet / application level.
    */
   recordEvent?(
     eventId: string,

--- a/src/nwc/NWCWalletServiceRequestHandler.ts
+++ b/src/nwc/NWCWalletServiceRequestHandler.ts
@@ -28,7 +28,21 @@ export type NWCWalletServiceResponsePromise<T> = Promise<{
   error: NWCWalletServiceRequestHandlerError;
 }>;
 
+export type NWCWalletServiceRecordEventResult = "ALREADY_PROCESSED" | undefined;
+
 export interface NWCWalletServiceRequestHandler {
+  /**
+   * Called with the request event id after the event is decrypted and parsed,
+   * but before it is handled. Return "ALREADY_PROCESSED" to skip handling,
+   * e.g. if a relay re-delivers an event that was already processed.
+   * Calls are serialized by the wallet service, so duplicates delivered in
+   * quick succession will still be seen one at a time.
+   */
+  recordEvent?(
+    eventId: string,
+  ):
+    | NWCWalletServiceRecordEventResult
+    | Promise<NWCWalletServiceRecordEventResult>;
   getInfo?(): NWCWalletServiceResponsePromise<Nip47GetInfoResponse>;
   makeInvoice?(
     request: Nip47MakeInvoiceRequest,

--- a/src/nwc/ReconnectingPool.test.ts
+++ b/src/nwc/ReconnectingPool.test.ts
@@ -110,8 +110,8 @@ describe("ReconnectingPool.close", () => {
     pool.close([RELAY_URL]);
 
     await expect(pool.ensureRelay(RELAY_URL)).rejects.toThrow("pool is closed");
-    await expect(
-      Promise.any(pool.publish([RELAY_URL], {} as never)),
-    ).resolves.toContain("pool is closed");
+    await expect(pool.publish([RELAY_URL], {} as never)[0]).rejects.toThrow(
+      "pool is closed",
+    );
   });
 });

--- a/src/nwc/ReconnectingPool.ts
+++ b/src/nwc/ReconnectingPool.ts
@@ -41,7 +41,11 @@ const MAX_KNOWN_IDS = 1000;
 export class ReconnectingPool {
   protected relays: Map<string, Relay> = new Map();
   // set by close()/destroy(); a closed pool is not usable anymore
-  private closed = false;
+  private _closed = false;
+
+  get closed() {
+    return this._closed;
+  }
 
   public enablePing: boolean | undefined;
   public maxWaitForConnection: number;
@@ -58,7 +62,7 @@ export class ReconnectingPool {
       abort?: AbortSignal;
     },
   ): Promise<Relay> {
-    if (this.closed) {
+    if (this._closed) {
       throw new Error("pool is closed");
     }
     url = normalizeURL(url);
@@ -90,7 +94,7 @@ export class ReconnectingPool {
 
     // the pool may have been closed while the connection was in flight; a
     // relay handed out now would have no owner to close it later
-    if (this.closed) {
+    if (this._closed) {
       relay.close();
       this.relays.delete(url);
       throw new Error("pool is closed");
@@ -102,7 +106,7 @@ export class ReconnectingPool {
   close(relays: string[]) {
     // subscription reconnect loops observe this flag and stop instead of
     // re-opening the relays closed below
-    this.closed = true;
+    this._closed = true;
     relays.map(normalizeURL).forEach((url) => {
       this.relays.get(url)?.close();
       this.relays.delete(url);
@@ -139,7 +143,7 @@ export class ReconnectingPool {
     };
 
     const waitForReconnect = (attempt: number): Promise<void> => {
-      if (closed || this.closed) return Promise.resolve();
+      if (closed || this._closed) return Promise.resolve();
       const delay = Math.min(
         INITIAL_RECONNECT_DELAY_MS * 2 ** attempt,
         MAX_RECONNECT_DELAY_MS,
@@ -160,7 +164,7 @@ export class ReconnectingPool {
 
     const runRelay = async (url: string) => {
       let attempt = 0;
-      while (!closed && !this.closed) {
+      while (!closed && !this._closed) {
         let relay: Relay;
         try {
           relay = await this.ensureRelay(url, {
@@ -168,14 +172,14 @@ export class ReconnectingPool {
             abort: params.abort,
           });
         } catch (err) {
-          if (closed || this.closed) return;
+          if (closed || this._closed) return;
           const reason = (err as { message?: string })?.message || String(err);
           params.ondisconnect?.(url, reason);
           await waitForReconnect(attempt++);
           continue;
         }
 
-        if (closed || this.closed) return;
+        if (closed || this._closed) return;
         params.onconnect?.(url);
         attempt = 0;
 
@@ -191,7 +195,7 @@ export class ReconnectingPool {
         });
 
         activeSubs.delete(url);
-        if (closed || this.closed) return;
+        if (closed || this._closed) return;
         params.ondisconnect?.(url, closeReason);
         await waitForReconnect(attempt++);
       }
@@ -232,7 +236,9 @@ export class ReconnectingPool {
           abort: params?.abort,
         });
       } catch (err) {
-        return String("connection failure: " + String(err));
+        // reject rather than resolve with an error message, so callers
+        // using Promise.any can detect that no relay accepted the event
+        throw new Error("connection failure: " + String(err));
       }
 
       return r.publish(event);
@@ -247,7 +253,7 @@ export class ReconnectingPool {
   }
 
   destroy(): void {
-    this.closed = true;
+    this._closed = true;
     this.relays.forEach((conn) => conn.close());
     this.relays = new Map();
   }


### PR DESCRIPTION
## Summary

Part of #577.

Adds an optional `recordEvent` method to `NWCWalletServiceRequestHandler`:

```ts
recordEvent?(
  eventId: string,
): NWCWalletServiceRecordEventResult | Promise<NWCWalletServiceRecordEventResult>;
```

It is called with the request event id after the event is decrypted and parsed, but before the request is handled. Returning `"ALREADY_PROCESSED"` makes the wallet service skip the request without responding (logged at debug level). This lets apps persist processed event ids (e.g. in their database) and deduplicate requests that a relay re-delivers — including across restarts, which the in-memory `knownIds` set in `ReconnectingPool` cannot cover.

`recordEvent` calls are serialized through a per-subscription promise queue, so duplicate events delivered in quick succession cannot pass an async check-then-record concurrently.

The `since`/`until` filter bounds from #577 are intentionally left for a separate PR.

## Response publish retries

While testing this end-to-end, the response event publish turned out to be a fire-and-forget `Promise.any` with no rejection handler — if all relays fail (or the pool is closed before the relay acks), it causes an unhandled promise rejection, which can crash a Node app. The publish now retries with exponential backoff (1s, 2s, 4s, 8s, 16s; 6 attempts total), logs each failed attempt, and stops retrying once the subscription is closed.

## Tests

- New unit tests (`src/nwc/NWCWalletService.test.ts`, first ones for `NWCWalletService`) run against a mocked pool with real signed + nip44-encrypted request events: normal handling, skipping on `"ALREADY_PROCESSED"`, serialization of concurrent duplicates, publish retry with backoff, and retry cancellation on unsubscribe.
- New e2e test (`e2e/nwc-wallet-service-record-event.test.ts`) runs a real `NWCWalletService` and `NWCClient` against relay.getalby.com and verifies the handler receives the request event id, and that a skipped request never reaches the handler and gets no response. (The relay-replays-old-events scenario itself can't be forced e2e since kind 23194 is in the ephemeral range.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Prevented previously processed wallet requests from being handled or answered again.
  * Serialized request processing to avoid duplicate handling during concurrent delivery.
  * Added automatic retries with increasing delays when publishing responses.
  * Stopped pending response retries when a subscription is closed.

* **Integration**
  * Added an optional event-recording hook so integrations can identify and skip requests they have already processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->