### PR TITLE
fix: stop subscription reconnect loops when ReconnectingPool is closed

### DIFF
--- a/e2e/nwc-close-in-flight-request.test.ts
+++ b/e2e/nwc-close-in-flight-request.test.ts
@@ -1,0 +1,59 @@
+import { generateSecretKey, getPublicKey } from "nostr-tools";
+import { bytesToHex } from "@noble/hashes/utils.js";
+import { NWCClient } from "../src/nwc/NWCClient";
+import {
+  NWCWalletService,
+  NWCWalletServiceKeyPair,
+} from "../src/nwc/NWCWalletService";
+
+const RELAY_URL = "wss://relay.getalby.com/v1";
+
+function getOpenTlsSockets(): number {
+  const handles = (
+    process as unknown as { _getActiveHandles: () => unknown[] }
+  )._getActiveHandles();
+  return handles.filter(
+    (h) =>
+      (h as object).constructor.name === "TLSSocket" &&
+      (h as { readyState?: string }).readyState === "open",
+  ).length;
+}
+
+test("closing a client with an in-flight request leaks no socket", async () => {
+  const walletSecret = bytesToHex(generateSecretKey());
+  const clientSecret = generateSecretKey();
+  const keypair = new NWCWalletServiceKeyPair(
+    walletSecret,
+    getPublicKey(clientSecret),
+  );
+
+  const service = new NWCWalletService({ relayUrls: [RELAY_URL] });
+  await service.publishWalletServiceInfoEvent(walletSecret, ["get_info"], []);
+  const unsubscribe = await service.subscribe(keypair, {
+    // never respond, so the client's request stays in flight
+    getInfo: () => new Promise(() => {}),
+  });
+
+  const client = new NWCClient({
+    nostrWalletConnectUrl: `nostr+walletconnect://${
+      keypair.walletPubkey
+    }?relay=${encodeURIComponent(RELAY_URL)}&secret=${bytesToHex(
+      clientSecret,
+    )}`,
+  });
+
+  const getInfoPromise = client.getInfo().catch(() => "error");
+  // give the request time to be published and reach the wallet service
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+
+  // close everything while the request is still awaiting a reply
+  client.close();
+  unsubscribe();
+  service.close();
+
+  // previously the in-flight request's subscription would reconnect
+  // ~1s after close and leave the new socket open forever
+  await new Promise((resolve) => setTimeout(resolve, 12000));
+  expect(getOpenTlsSockets()).toBe(0);
+  await getInfoPromise;
+}, 40_000);

--- a/src/nwc/ReconnectingPool.test.ts
+++ b/src/nwc/ReconnectingPool.test.ts
@@ -1,0 +1,117 @@
+import { Relay } from "nostr-tools";
+import { ReconnectingPool } from "./ReconnectingPool";
+
+type FakeSubscriptionParams = {
+  onclose?: (reason: string) => void;
+};
+
+// replaces pool.ensureRelay with a fake so no network is involved.
+// returns helpers to count connections and simulate relay disconnects.
+function mockEnsureRelay(pool: ReconnectingPool) {
+  const ensureRelayCalls: string[] = [];
+  const subscriptionParams = new Map<string, FakeSubscriptionParams>();
+
+  pool.ensureRelay = async (url: string) => {
+    ensureRelayCalls.push(url);
+    return {
+      subscribe: (
+        _filters: unknown,
+        params: FakeSubscriptionParams,
+      ): unknown => {
+        subscriptionParams.set(url, params);
+        return {
+          close: (reason?: string) =>
+            params.onclose?.(reason || "closed by caller"),
+        };
+      },
+      close: () => {},
+    } as unknown as Relay;
+  };
+
+  return {
+    ensureRelayCalls,
+    disconnect: (url: string) => {
+      subscriptionParams.get(url)?.onclose?.("relay connection closed");
+    },
+  };
+}
+
+const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0));
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const RELAY_URL = "wss://relay.getalby.com/v1";
+
+describe("ReconnectingPool.close", () => {
+  test("stops subscription reconnect loops so closed relays are not re-opened", async () => {
+    const pool = new ReconnectingPool();
+    const { ensureRelayCalls, disconnect } = mockEnsureRelay(pool);
+
+    pool.subscribe([RELAY_URL], { kinds: [23194] }, {});
+    await flushMicrotasks();
+    expect(ensureRelayCalls).toEqual([RELAY_URL]);
+
+    // relay disconnects; the subscription now waits 1s to reconnect
+    disconnect(RELAY_URL);
+    await flushMicrotasks();
+
+    // closing the pool during that wait must stop the reconnect loop -
+    // previously the loop reconnected after the backoff, opening a new
+    // socket that nothing ever closed
+    pool.close([RELAY_URL]);
+    await sleep(1200);
+    expect(ensureRelayCalls).toEqual([RELAY_URL]);
+  }, 10_000);
+
+  test("closing while the subscription is connected does not reconnect", async () => {
+    const pool = new ReconnectingPool();
+    const { ensureRelayCalls, disconnect } = mockEnsureRelay(pool);
+
+    pool.subscribe([RELAY_URL], { kinds: [23194] }, {});
+    await flushMicrotasks();
+
+    // pool.close closes the relay, which disconnects the inner
+    // subscription - the loop must treat this as final
+    pool.close([RELAY_URL]);
+    disconnect(RELAY_URL);
+    await sleep(1200);
+    expect(ensureRelayCalls).toEqual([RELAY_URL]);
+  }, 10_000);
+
+  test("destroy stops subscription reconnect loops", async () => {
+    const pool = new ReconnectingPool();
+    const { ensureRelayCalls, disconnect } = mockEnsureRelay(pool);
+
+    pool.subscribe([RELAY_URL], { kinds: [23194] }, {});
+    await flushMicrotasks();
+
+    disconnect(RELAY_URL);
+    await flushMicrotasks();
+    pool.destroy();
+    await sleep(1200);
+    expect(ensureRelayCalls).toEqual([RELAY_URL]);
+  }, 10_000);
+
+  test("closing the subscription itself still stops reconnects", async () => {
+    const pool = new ReconnectingPool();
+    const { ensureRelayCalls, disconnect } = mockEnsureRelay(pool);
+
+    const sub = pool.subscribe([RELAY_URL], { kinds: [23194] }, {});
+    await flushMicrotasks();
+
+    disconnect(RELAY_URL);
+    await flushMicrotasks();
+    sub.close();
+    await sleep(1200);
+    expect(ensureRelayCalls).toEqual([RELAY_URL]);
+  }, 10_000);
+
+  test("a closed pool cannot open new connections", async () => {
+    const pool = new ReconnectingPool();
+    pool.close([RELAY_URL]);
+
+    await expect(pool.ensureRelay(RELAY_URL)).rejects.toThrow("pool is closed");
+    await expect(
+      Promise.any(pool.publish([RELAY_URL], {} as never)),
+    ).resolves.toContain("pool is closed");
+  });
+});

--- a/src/nwc/ReconnectingPool.ts
+++ b/src/nwc/ReconnectingPool.ts
@@ -88,6 +88,14 @@ export class ReconnectingPool {
       throw err;
     }
 
+    // the pool may have been closed while the connection was in flight; a
+    // relay handed out now would have no owner to close it later
+    if (this.closed) {
+      relay.close();
+      this.relays.delete(url);
+      throw new Error("pool is closed");
+    }
+
     return relay;
   }
 

--- a/src/nwc/ReconnectingPool.ts
+++ b/src/nwc/ReconnectingPool.ts
@@ -40,6 +40,8 @@ const MAX_KNOWN_IDS = 1000;
 
 export class ReconnectingPool {
   protected relays: Map<string, Relay> = new Map();
+  // set by close()/destroy(); a closed pool is not usable anymore
+  private closed = false;
 
   public enablePing: boolean | undefined;
   public maxWaitForConnection: number;
@@ -56,6 +58,9 @@ export class ReconnectingPool {
       abort?: AbortSignal;
     },
   ): Promise<Relay> {
+    if (this.closed) {
+      throw new Error("pool is closed");
+    }
     url = normalizeURL(url);
 
     let relay = this.relays.get(url);
@@ -87,6 +92,9 @@ export class ReconnectingPool {
   }
 
   close(relays: string[]) {
+    // subscription reconnect loops observe this flag and stop instead of
+    // re-opening the relays closed below
+    this.closed = true;
     relays.map(normalizeURL).forEach((url) => {
       this.relays.get(url)?.close();
       this.relays.delete(url);
@@ -123,7 +131,7 @@ export class ReconnectingPool {
     };
 
     const waitForReconnect = (attempt: number): Promise<void> => {
-      if (closed) return Promise.resolve();
+      if (closed || this.closed) return Promise.resolve();
       const delay = Math.min(
         INITIAL_RECONNECT_DELAY_MS * 2 ** attempt,
         MAX_RECONNECT_DELAY_MS,
@@ -144,7 +152,7 @@ export class ReconnectingPool {
 
     const runRelay = async (url: string) => {
       let attempt = 0;
-      while (!closed) {
+      while (!closed && !this.closed) {
         let relay: Relay;
         try {
           relay = await this.ensureRelay(url, {
@@ -152,14 +160,14 @@ export class ReconnectingPool {
             abort: params.abort,
           });
         } catch (err) {
-          if (closed) return;
+          if (closed || this.closed) return;
           const reason = (err as { message?: string })?.message || String(err);
           params.ondisconnect?.(url, reason);
           await waitForReconnect(attempt++);
           continue;
         }
 
-        if (closed) return;
+        if (closed || this.closed) return;
         params.onconnect?.(url);
         attempt = 0;
 
@@ -175,7 +183,7 @@ export class ReconnectingPool {
         });
 
         activeSubs.delete(url);
-        if (closed) return;
+        if (closed || this.closed) return;
         params.ondisconnect?.(url, closeReason);
         await waitForReconnect(attempt++);
       }
@@ -231,6 +239,7 @@ export class ReconnectingPool {
   }
 
   destroy(): void {
+    this.closed = true;
     this.relays.forEach((conn) => conn.close());
     this.relays = new Map();
   }


### PR DESCRIPTION
## Summary

Fixes #579.

Closing a `ReconnectingPool` (e.g. via `NWCClient.close()`) while a subscription was still active did not stop the subscription's reconnect loop: the loop observed the disconnect caused by `close()`, waited out its backoff, and re-opened a brand-new relay socket. Nothing ever closed that socket — leaked sockets in long-lived apps, hangs on exit in short-lived ones.

## Fix

Closing a pool is terminal (closing and re-using a pool was never supported), so the fix is a single pool-level `closed` flag:

- `close()` and `destroy()` set `closed = true` before closing the relay sockets.
- The reconnect loops in `subscribe()` check the flag at their existing exit points and stop instead of reconnecting. Loops mid-backoff exit when their timer fires; no new socket is ever opened.
- `ensureRelay()` throws on a closed pool, so no code path (subscribe loops, late publishes) can open a connection after close. The publish path already converts `ensureRelay` failures into a resolved "connection failure" string, so this surfaces gracefully.

Net change to `ReconnectingPool.ts`: +14/-5 lines.

## Tests

- New unit tests (`src/nwc/ReconnectingPool.test.ts`) mock `ensureRelay` (no network) and cover: close during reconnect backoff, close while connected, `destroy()`, closing the subscription itself, and the closed pool refusing new connections. The two close/destroy reconnect tests fail against the previous implementation.
- New e2e test (`e2e/nwc-close-in-flight-request.test.ts`) reproduces the original leak against relay.getalby.com: a client is closed while a `get_info` request is in flight (wallet service never responds), and 12s later no open TLS socket remains (verified via `process._getActiveHandles()`). Fails with 1 leaked socket on master, passes with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection shutdown behavior to prevent relay reconnections after the client, subscription, or wallet service is closed.
  * Closed connection pools now reject new relay connections and stop reconnect attempts.
  * Prevented lingering TLS sockets after closing during an in-flight request or reconnect backoff.

* **Tests**
  * Added comprehensive coverage for connection-pool lifecycle and shutdown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->