### PR TITLE
feat: add optional since/until filter to NWCWalletService.subscribe

### DIFF
--- a/docs/nwc-wallet-service.md
+++ b/docs/nwc-wallet-service.md
@@ -52,3 +52,5 @@ const unsub = await walletService.subscribe(keypair, {
   // ... handle other NIP-47 methods here
 });
 ```
+
+`subscribe()` accepts an optional third argument `{ since?, until? }` (unix seconds) that is passed through to the NIP-01 request filter. Use a persisted high-water mark as `since` to limit replay of retained history on resubscribe. Relays can ignore these bounds, so keep using `recordEvent` for idempotency. 

--- a/src/nwc/NWCWalletService.test.ts
+++ b/src/nwc/NWCWalletService.test.ts
@@ -1,6 +1,10 @@
-import { generateSecretKey, getPublicKey, Event } from "nostr-tools";
+import { generateSecretKey, getPublicKey, Event, Filter } from "nostr-tools";
 import { bytesToHex } from "@noble/hashes/utils.js";
-import { NWCWalletService, NWCWalletServiceKeyPair } from "./NWCWalletService";
+import {
+  NWCWalletService,
+  NWCWalletServiceKeyPair,
+  NWCWalletServiceSubscribeFilter,
+} from "./NWCWalletService";
 import { NWCWalletServiceRequestHandler } from "./NWCWalletServiceRequestHandler";
 import { Nip47GetInfoResponse } from "./types";
 
@@ -10,6 +14,7 @@ type SubscribeParams = {
 
 async function setupSubscribedWalletService(
   handler: NWCWalletServiceRequestHandler,
+  filter?: NWCWalletServiceSubscribeFilter,
 ) {
   const walletSecret = bytesToHex(generateSecretKey());
   const clientSecret = generateSecretKey();
@@ -24,7 +29,9 @@ async function setupSubscribedWalletService(
   });
 
   let subscribeParams: SubscribeParams | undefined;
-  service.pool.subscribe = (_relayUrls, _filter, params) => {
+  let subscribeFilter: Filter | undefined;
+  service.pool.subscribe = (_relayUrls, poolFilter, params) => {
+    subscribeFilter = poolFilter;
     subscribeParams = params as SubscribeParams;
     return { close: () => {} } as ReturnType<typeof service.pool.subscribe>;
   };
@@ -33,8 +40,8 @@ async function setupSubscribedWalletService(
     service as unknown as { _checkConnected: () => Promise<void> }
   )._checkConnected = () => Promise.resolve();
 
-  const unsubscribe = await service.subscribe(keypair, handler);
-  if (!subscribeParams) {
+  const unsubscribe = await service.subscribe(keypair, handler, filter);
+  if (!subscribeParams || !subscribeFilter) {
     throw new Error("subscribe was not called on the pool");
   }
 
@@ -56,7 +63,14 @@ async function setupSubscribedWalletService(
     bytesToHex(clientSecret),
   );
 
-  return { service, subscribeParams, requestEvent, unsubscribe };
+  return {
+    service,
+    subscribeParams,
+    subscribeFilter,
+    requestEvent,
+    unsubscribe,
+    keypair,
+  };
 }
 
 const getInfoResponse = {
@@ -204,4 +218,46 @@ describe("response publishing", () => {
     await new Promise((resolve) => setTimeout(resolve, 1200));
     expect(publishCalls).toBe(1);
   }, 10_000);
+});
+
+describe("subscribe filter", () => {
+  test("omits since and until when no filter is provided", async () => {
+    const { subscribeFilter, keypair } = await setupSubscribedWalletService({});
+
+    expect(subscribeFilter).toEqual({
+      kinds: [23194],
+      authors: [keypair.clientPubkey],
+      "#p": [keypair.walletPubkey],
+    });
+    expect(subscribeFilter).not.toHaveProperty("since");
+    expect(subscribeFilter).not.toHaveProperty("until");
+  });
+
+  test("includes since and until when provided", async () => {
+    const since = 1_700_000_000;
+    const until = 1_800_000_000;
+    const { subscribeFilter, keypair } = await setupSubscribedWalletService(
+      {},
+      { since, until },
+    );
+
+    expect(subscribeFilter).toEqual({
+      kinds: [23194],
+      authors: [keypair.clientPubkey],
+      "#p": [keypair.walletPubkey],
+      since,
+      until,
+    });
+  });
+
+  test("includes only the bounds that are set", async () => {
+    const since = 1_700_000_000;
+    const { subscribeFilter } = await setupSubscribedWalletService(
+      {},
+      { since },
+    );
+
+    expect(subscribeFilter.since).toBe(since);
+    expect(subscribeFilter).not.toHaveProperty("until");
+  });
 });

--- a/src/nwc/NWCWalletService.ts
+++ b/src/nwc/NWCWalletService.ts
@@ -34,6 +34,18 @@ export type NewNWCWalletServiceOptions = {
   logger?: Logger;
 };
 
+/**
+ * Optional NIP-01 time bounds for the kind 23194 request subscription.
+ * Use a persisted high-water mark (e.g. last seen `created_at`) as `since`
+ * to limit replay of retained history on resubscribe. This is a best-effort
+ * bound for well-behaved relays; non-compliant relays can ignore `since` /
+ * `until`. Keep using `recordEvent` for idempotency.
+ */
+export type NWCWalletServiceSubscribeFilter = {
+  since?: number;
+  until?: number;
+};
+
 // First retry waits 1s; each subsequent attempt doubles (1s, 2s, 4s, 8s, 16s).
 const INITIAL_PUBLISH_RETRY_DELAY_MS = 1000;
 const MAX_PUBLISH_ATTEMPTS = 6;
@@ -99,6 +111,7 @@ export class NWCWalletService {
   async subscribe(
     keypair: NWCWalletServiceKeyPair,
     handler: NWCWalletServiceRequestHandler,
+    filter?: NWCWalletServiceSubscribeFilter,
   ): Promise<() => void> {
     this.logger.debug("checking connection to relays");
     await this._checkConnected();
@@ -118,6 +131,8 @@ export class NWCWalletService {
         kinds: [23194],
         authors: [keypair.clientPubkey],
         "#p": [keypair.walletPubkey],
+        ...(filter?.since !== undefined ? { since: filter.since } : {}),
+        ...(filter?.until !== undefined ? { until: filter.until } : {}),
       },
 
       {


### PR DESCRIPTION
## Summary
- Adds an optional third argument to `NWCWalletService.subscribe()` (`{ since?, until? }` in unix seconds) that is passed through to the NIP-01 kind 23194 request filter.
- Bounds are omitted unless set, so existing callers keep the previous unbounded subscription.
- This is a complementary bound for well-behaved relays that retain request history across resubscribe; `recordEvent` remains the idempotency path.

Closes #577

## Test plan
- [ ] Unit tests: `src/nwc/NWCWalletService.test.ts` (omit both bounds, include both, include `since` only)
- [ ] Confirm existing `subscribe(keypair, handler)` callers still type-check and subscribe without `since`/`until`
- [ ] Optional: subscribe with `since` set to a recent high-water mark against a retaining relay and confirm older events are not delivered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional `since` and `until` time filters to wallet service subscriptions.
  - Supports limiting replayed events during initial subscriptions and resubscriptions.

- **Documentation**
  - Updated the wallet service quick-start guide with filter usage, Unix-second formatting, and persisted high-water mark behavior.

- **Tests**
  - Added coverage for default, complete, and partially specified subscription filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->