### PR TITLE
feat: add publishNotification to NWCWalletService

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,5 +26,13 @@
   },
   "globals": {
     "window": true
-  }
+  },
+  "overrides": [
+    {
+      "files": ["examples/**"],
+      "rules": {
+        "no-console": "off"
+      }
+    }
+  ]
 }

--- a/docs/nwc-wallet-service.md
+++ b/docs/nwc-wallet-service.md
@@ -57,13 +57,13 @@ const unsub = await walletService.subscribe(keypair, {
 
 `subscribe()` accepts an optional third argument `{ since?, until? }` (unix seconds) that is passed through to the NIP-01 request filter. Use a persisted high-water mark as `since` to limit replay of retained history on resubscribe. Relays can ignore these bounds, so keep using `recordEvent` for idempotency.
 
-### `publishNotification(keypair, notification, options?)`
+### `publishNotification(keypair, notification)`
 
 Publish a [NIP-47 notification](https://github.com/nostr-protocol/nips/blob/master/47.md) to a connected client. Clients receive these events via `NWCClient.subscribeNotifications()`.
 
 Advertise the same notification types in `publishWalletServiceInfoEvent()` so clients know they can subscribe.
 
-By default this publishes both encryption kinds advertised on the info event: `nip44_v2` (kind `23197`) and `nip04` (kind `23196`). Pass `encryptionTypes` only if you need to restrict that.
+Always publishes both encryption kinds advertised on the info event: `nip44_v2` (kind `23197`) and `nip04` (kind `23196`).
 
 ```js
 await walletService.publishNotification(keypair, {

--- a/docs/nwc-wallet-service.md
+++ b/docs/nwc-wallet-service.md
@@ -10,30 +10,32 @@ The Alby JS SDK allows you to easily integrate Nostr Wallet Connect into any Jav
 
 ### Initialization Options
 
-- `relayUrl`: URL of the Nostr relay to be used (e.g. wss://relay.getalby.com/v1)
+- `relayUrls`: URLs of the Nostr relays to be used (e.g. `["wss://relay.getalby.com/v1"]`)
 
 ### NWCWalletService quick start example
 
 See [the full example](/examples/nwc/wallet-service/example.js)
 
 ```js
-import { NWCWalletService } from "@getalby/sdk/nwc";
+import { NWCWalletService, NWCWalletServiceKeyPair } from "@getalby/sdk/nwc";
 
 const walletService = new NWCWalletService({
-  relayUrl: "wss://relay.getalby.com/v1",
+  relayUrls: ["wss://relay.getalby.com/v1"],
 });
 
-// now for each client/app connection you can publish a NIP-47 info event and subscribe to requests
+// load from storage: one wallet secret for the service, a distinct client pubkey per connection
+const walletServiceSecretKey = "..."; // hex
+const clientPubkey = "..."; // hex
 
+// publish the NIP-47 info event once per wallet (not once per client)
 await walletService.publishWalletServiceInfoEvent(
   walletServiceSecretKey,
   ["get_info"], // NIP-47 methods supported by your wallet service
-  [],
+  ["payment_received", "payment_sent"], // NIP-47 notifications supported by your wallet service
 );
 
-// each client connection will have a unique keypair
-
-const keypair = new nwc.NWCWalletServiceKeyPair(
+// for each client, create a key pair and subscribe separately
+const keypair = new NWCWalletServiceKeyPair(
   walletServiceSecretKey,
   clientPubkey,
 );
@@ -53,4 +55,23 @@ const unsub = await walletService.subscribe(keypair, {
 });
 ```
 
-`subscribe()` accepts an optional third argument `{ since?, until? }` (unix seconds) that is passed through to the NIP-01 request filter. Use a persisted high-water mark as `since` to limit replay of retained history on resubscribe. Relays can ignore these bounds, so keep using `recordEvent` for idempotency. 
+`subscribe()` accepts an optional third argument `{ since?, until? }` (unix seconds) that is passed through to the NIP-01 request filter. Use a persisted high-water mark as `since` to limit replay of retained history on resubscribe. Relays can ignore these bounds, so keep using `recordEvent` for idempotency.
+
+### `publishNotification(keypair, notification, options?)`
+
+Publish a [NIP-47 notification](https://github.com/nostr-protocol/nips/blob/master/47.md) to a connected client. Clients receive these events via `NWCClient.subscribeNotifications()`.
+
+Advertise the same notification types in `publishWalletServiceInfoEvent()` so clients know they can subscribe.
+
+`NWCWalletService` advertises both `nip44_v2` and `nip04` on the info event. Pass both `encryptionTypes` so modern clients (kind `23197`) and legacy clients (kind `23196`) receive the notification:
+
+```js
+await walletService.publishNotification(
+  keypair,
+  {
+    notification_type: "payment_received", // or "payment_sent"
+    notification: transaction, // Nip47Transaction
+  },
+  { encryptionTypes: ["nip44_v2", "nip04"] },
+);
+```

--- a/docs/nwc-wallet-service.md
+++ b/docs/nwc-wallet-service.md
@@ -14,7 +14,7 @@ The Alby JS SDK allows you to easily integrate Nostr Wallet Connect into any Jav
 
 ### NWCWalletService quick start example
 
-See [the full example](/examples/nwc/wallet-service/example.js)
+See [get_info](/examples/nwc/wallet-service/get-info.ts) and [notifications](/examples/nwc/wallet-service/notifications.ts) (fake `pay_invoice` + `payment_sent`).
 
 ```js
 import { NWCWalletService, NWCWalletServiceKeyPair } from "@getalby/sdk/nwc";
@@ -31,7 +31,7 @@ const clientPubkey = "..."; // hex
 await walletService.publishWalletServiceInfoEvent(
   walletServiceSecretKey,
   ["get_info"], // NIP-47 methods supported by your wallet service
-  ["payment_received", "payment_sent"], // NIP-47 notifications supported by your wallet service
+  [], // only advertise notifications your service actually publishes
 );
 
 // for each client, create a key pair and subscribe separately
@@ -63,15 +63,11 @@ Publish a [NIP-47 notification](https://github.com/nostr-protocol/nips/blob/mast
 
 Advertise the same notification types in `publishWalletServiceInfoEvent()` so clients know they can subscribe.
 
-`NWCWalletService` advertises both `nip44_v2` and `nip04` on the info event. Pass both `encryptionTypes` so modern clients (kind `23197`) and legacy clients (kind `23196`) receive the notification:
+By default this publishes both encryption kinds advertised on the info event: `nip44_v2` (kind `23197`) and `nip04` (kind `23196`). Pass `encryptionTypes` only if you need to restrict that.
 
 ```js
-await walletService.publishNotification(
-  keypair,
-  {
-    notification_type: "payment_received", // or "payment_sent"
-    notification: transaction, // Nip47Transaction
-  },
-  { encryptionTypes: ["nip44_v2", "nip04"] },
-);
+await walletService.publishNotification(keypair, {
+  notification_type: "payment_received", // or "payment_sent"
+  notification: transaction, // Nip47Transaction
+});
 ```

--- a/docs/nwc.md
+++ b/docs/nwc.md
@@ -32,6 +32,16 @@ const nwcClient = new NWCClient({
 const response = await nwcClient.payInvoice({ invoice });
 ```
 
+### `subscribeNotifications(onNotification, notificationTypes?)`
+
+Subscribe to NIP-47 notifications published by the wallet service (for example `payment_received`). See [the subscribe example](../examples/nwc/client/subscribe.ts). Wallet services publish these events with `NWCWalletService.publishNotification()` — see [NWC wallet service documentation](./nwc-wallet-service.md).
+
+```js
+const unsub = await nwcClient.subscribeNotifications((notification) => {
+  console.log(notification.notification_type, notification.notification);
+});
+```
+
 ### `static fromAuthorizationUrl()`
 
 Initialized a new `NWCClient` instance but generates a new random secret. The pubkey of that secret then needs to be authorized by the user (this can be initiated by redirecting the user to the `getAuthorizationUrl()` URL or calling `fromAuthorizationUrl()` to open an authorization popup.

--- a/examples/nwc/wallet-service/example.ts
+++ b/examples/nwc/wallet-service/example.ts
@@ -33,7 +33,7 @@ const walletService = new NWCWalletService({
 await walletService.publishWalletServiceInfoEvent(
   walletServiceSecretKey,
   ["get_info"],
-  [],
+  ["payment_received", "payment_sent"],
 );
 
 const keypair = new NWCWalletServiceKeyPair(

--- a/examples/nwc/wallet-service/get-info.ts
+++ b/examples/nwc/wallet-service/get-info.ts
@@ -33,7 +33,7 @@ const walletService = new NWCWalletService({
 await walletService.publishWalletServiceInfoEvent(
   walletServiceSecretKey,
   ["get_info"],
-  ["payment_received", "payment_sent"],
+  [],
 );
 
 const keypair = new NWCWalletServiceKeyPair(

--- a/examples/nwc/wallet-service/get-info.ts
+++ b/examples/nwc/wallet-service/get-info.ts
@@ -1,5 +1,5 @@
 import { generateSecretKey, getPublicKey } from "nostr-tools";
-import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils.js";
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 
@@ -43,6 +43,7 @@ const keypair = new NWCWalletServiceKeyPair(
 
 const unsub = await walletService.subscribe(keypair, {
   getInfo: () => {
+    console.info("get_info requested");
     return Promise.resolve({
       result: {
         methods: ["get_info"],

--- a/examples/nwc/wallet-service/notifications.ts
+++ b/examples/nwc/wallet-service/notifications.ts
@@ -1,5 +1,5 @@
 import { generateSecretKey, getPublicKey } from "nostr-tools";
-import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils.js";
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 
@@ -32,7 +32,7 @@ const nwcUrl = `nostr+walletconnect://${walletServicePubkey}?${searchParams}`;
 
 output.write(`enter this NWC URL in a client: ${nwcUrl}\n`);
 output.write(
-  "This example does not send real payments. pay_invoice returns a dummy preimage/fee and publishes a payment_sent notification.\n",
+  "This example does not send real payments. pay_invoice returns a dummy preimage/fee and publishes a payment_sent notification.\nRecommended setup: Run nwc/client/pay-invoice and nwc/client/subscribe examples with this NWC URL and paste any valid lightning invoice to test the full flow.\n",
 );
 
 import {
@@ -93,14 +93,15 @@ const unsub = await walletService.subscribe(keypair, {
       expires_at: now,
     };
 
-    void walletService
-      .publishNotification(keypair, {
+    try {
+      await walletService.publishNotification(keypair, {
         notification_type: "payment_sent",
         notification: transaction,
-      })
-      .catch((error) => {
-        console.error("failed to publish payment_sent notification", error);
       });
+      console.info("published payment_sent notification");
+    } catch (error) {
+      console.error("failed to publish payment_sent notification", error);
+    }
 
     return {
       result: { preimage, fees_paid: feesPaid },

--- a/examples/nwc/wallet-service/notifications.ts
+++ b/examples/nwc/wallet-service/notifications.ts
@@ -20,11 +20,16 @@ const relayUrls = (
 ).split(",");
 rl.close();
 
-const nwcUrl = `nostr+walletconnect://${walletServicePubkey}?relay=${relayUrls.join("&relay=")}&secret=${clientSecretKey}`;
+const searchParams = new URLSearchParams();
+for (const relayUrl of relayUrls) {
+  searchParams.append("relay", relayUrl.trim());
+}
+searchParams.set("secret", clientSecretKey);
+const nwcUrl = `nostr+walletconnect://${walletServicePubkey}?${searchParams}`;
 
-console.info("enter this NWC URL in a client: ", nwcUrl);
-console.info(
-  "This example does not send real payments. pay_invoice returns a dummy preimage/fee and publishes a payment_sent notification.",
+output.write(`enter this NWC URL in a client: ${nwcUrl}\n`);
+output.write(
+  "This example does not send real payments. pay_invoice returns a dummy preimage/fee and publishes a payment_sent notification.\n",
 );
 
 import {
@@ -85,10 +90,14 @@ const unsub = await walletService.subscribe(keypair, {
       expires_at: now,
     };
 
-    await walletService.publishNotification(keypair, {
-      notification_type: "payment_sent",
-      notification: transaction,
-    });
+    void walletService
+      .publishNotification(keypair, {
+        notification_type: "payment_sent",
+        notification: transaction,
+      })
+      .catch((error) => {
+        console.error("failed to publish payment_sent notification", error);
+      });
 
     return {
       result: { preimage, fees_paid: feesPaid },
@@ -97,9 +106,9 @@ const unsub = await walletService.subscribe(keypair, {
   },
 });
 
-console.info("Waiting for events...");
+output.write("Waiting for events...\n");
 process.on("SIGINT", function () {
-  console.info("Caught interrupt signal");
+  output.write("Caught interrupt signal\n");
 
   unsub();
   walletService.close();

--- a/examples/nwc/wallet-service/notifications.ts
+++ b/examples/nwc/wallet-service/notifications.ts
@@ -1,0 +1,108 @@
+import { generateSecretKey, getPublicKey } from "nostr-tools";
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils";
+import * as readline from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+
+const walletServiceSecretKey = bytesToHex(generateSecretKey());
+const walletServicePubkey = getPublicKey(hexToBytes(walletServiceSecretKey));
+
+const clientSecretKey = bytesToHex(generateSecretKey());
+const clientPubkey = getPublicKey(hexToBytes(clientSecretKey));
+
+const DEFAULT_RELAY_URLs = "wss://relay.getalby.com/v1";
+
+const rl = readline.createInterface({ input, output });
+
+const relayUrls = (
+  (await rl.question(
+    `Relay URLs, comma separated (${DEFAULT_RELAY_URLs}): `,
+  )) || DEFAULT_RELAY_URLs
+).split(",");
+rl.close();
+
+const nwcUrl = `nostr+walletconnect://${walletServicePubkey}?relay=${relayUrls.join("&relay=")}&secret=${clientSecretKey}`;
+
+console.info("enter this NWC URL in a client: ", nwcUrl);
+console.info(
+  "This example does not send real payments. pay_invoice returns a dummy preimage/fee and publishes a payment_sent notification.",
+);
+
+import {
+  NWCWalletService,
+  NWCWalletServiceKeyPair,
+  Nip47PayInvoiceRequest,
+} from "@getalby/sdk/nwc";
+
+const walletService = new NWCWalletService({
+  relayUrls,
+});
+
+// This example only fakes payment_sent; do not advertise types you never publish.
+await walletService.publishWalletServiceInfoEvent(
+  walletServiceSecretKey,
+  ["get_info", "pay_invoice"],
+  ["payment_sent"],
+);
+
+const keypair = new NWCWalletServiceKeyPair(
+  walletServiceSecretKey,
+  clientPubkey,
+);
+
+const unsub = await walletService.subscribe(keypair, {
+  getInfo: () => {
+    return Promise.resolve({
+      result: {
+        methods: ["get_info", "pay_invoice"],
+        notifications: ["payment_sent"],
+        alias: "Alby Hub",
+        color: "#EFA911",
+        pubkey: walletServicePubkey,
+        network: "mainnet",
+        block_height: 800000,
+        block_hash: "0000...0000",
+      },
+      error: undefined,
+    });
+  },
+  payInvoice: async (request: Nip47PayInvoiceRequest) => {
+    const now = Math.floor(Date.now() / 1000);
+    // Dummy values only — no Lightning payment is made.
+    const preimage = bytesToHex(generateSecretKey());
+    const feesPaid = 1000; // 1 sat, example only
+    const transaction = {
+      type: "outgoing" as const,
+      state: "settled" as const,
+      invoice: request.invoice,
+      description: "",
+      description_hash: "",
+      preimage,
+      payment_hash: "00".repeat(32),
+      amount: request.amount ?? 1000,
+      fees_paid: feesPaid,
+      settled_at: now,
+      created_at: now,
+      expires_at: now,
+    };
+
+    await walletService.publishNotification(keypair, {
+      notification_type: "payment_sent",
+      notification: transaction,
+    });
+
+    return {
+      result: { preimage, fees_paid: feesPaid },
+      error: undefined,
+    };
+  },
+});
+
+console.info("Waiting for events...");
+process.on("SIGINT", function () {
+  console.info("Caught interrupt signal");
+
+  unsub();
+  walletService.close();
+
+  process.exit();
+});

--- a/examples/nwc/wallet-service/notifications.ts
+++ b/examples/nwc/wallet-service/notifications.ts
@@ -17,12 +17,15 @@ const relayUrls = (
   (await rl.question(
     `Relay URLs, comma separated (${DEFAULT_RELAY_URLs}): `,
   )) || DEFAULT_RELAY_URLs
-).split(",");
+)
+  .split(",")
+  .map((relayUrl) => relayUrl.trim())
+  .filter(Boolean);
 rl.close();
 
 const searchParams = new URLSearchParams();
 for (const relayUrl of relayUrls) {
-  searchParams.append("relay", relayUrl.trim());
+  searchParams.append("relay", relayUrl);
 }
 searchParams.set("secret", clientSecretKey);
 const nwcUrl = `nostr+walletconnect://${walletServicePubkey}?${searchParams}`;
@@ -113,5 +116,5 @@ process.on("SIGINT", function () {
   unsub();
   walletService.close();
 
-  process.exit();
+  process.exitCode = 0;
 });

--- a/src/nwc/NWCWalletService.test.ts
+++ b/src/nwc/NWCWalletService.test.ts
@@ -305,7 +305,7 @@ function setupWalletService() {
 }
 
 describe("publishNotification", () => {
-  test("publishes both encryption kinds by default", async () => {
+  test("publishes both encryption kinds", async () => {
     const { service, keypair, publishedEvents } = setupWalletService();
 
     await service.publishNotification(keypair, paymentReceivedNotification);
@@ -332,30 +332,15 @@ describe("publishNotification", () => {
     ).toEqual(paymentReceivedNotification);
   });
 
-  test("publishes a single encryption kind when requested", async () => {
-    const { service, keypair, publishedEvents } = setupWalletService();
-
-    await service.publishNotification(keypair, paymentReceivedNotification, {
-      encryptionTypes: ["nip44_v2"],
-    });
-
-    expect(publishedEvents).toHaveLength(1);
-    expect(publishedEvents[0].kind).toBe(23197);
-    expect(
-      JSON.parse(
-        await service.decrypt(keypair, publishedEvents[0].content, "nip44_v2"),
-      ),
-    ).toEqual(paymentReceivedNotification);
-  });
-
   test("retries failed publishes with exponential backoff", async () => {
     const { service, keypair } = setupWalletService();
 
     let publishCalls = 0;
     service.pool.publish = () => {
       publishCalls++;
+      // both encryption kinds publish concurrently; fail each first attempt
       return [
-        publishCalls < 2
+        publishCalls <= 2
           ? Promise.reject(new Error("publish failed"))
           : Promise.resolve(""),
       ];
@@ -364,13 +349,12 @@ describe("publishNotification", () => {
     const publishPromise = service.publishNotification(
       keypair,
       paymentReceivedNotification,
-      { encryptionTypes: ["nip44_v2"] },
     );
 
     await new Promise((resolve) => setTimeout(resolve, 100));
-    expect(publishCalls).toBe(1);
+    expect(publishCalls).toBe(2);
 
     await publishPromise;
-    expect(publishCalls).toBe(2);
+    expect(publishCalls).toBe(4);
   }, 10_000);
 });

--- a/src/nwc/NWCWalletService.test.ts
+++ b/src/nwc/NWCWalletService.test.ts
@@ -6,7 +6,7 @@ import {
   NWCWalletServiceSubscribeFilter,
 } from "./NWCWalletService";
 import { NWCWalletServiceRequestHandler } from "./NWCWalletServiceRequestHandler";
-import { Nip47GetInfoResponse } from "./types";
+import { Nip47GetInfoResponse, Nip47Notification } from "./types";
 
 type SubscribeParams = {
   onevent: (event: Event) => Promise<void> | void;
@@ -260,4 +260,115 @@ describe("subscribe filter", () => {
     expect(subscribeFilter.since).toBe(since);
     expect(subscribeFilter).not.toHaveProperty("until");
   });
+});
+
+const paymentReceivedNotification: Nip47Notification = {
+  notification_type: "payment_received",
+  notification: {
+    type: "incoming",
+    state: "settled",
+    invoice: "lnbc1",
+    description: "",
+    description_hash: "",
+    preimage: "00",
+    payment_hash: "aa",
+    amount: 1000,
+    fees_paid: 0,
+    settled_at: 1,
+    created_at: 1,
+    expires_at: 2,
+  },
+};
+
+function setupWalletService() {
+  const walletSecret = bytesToHex(generateSecretKey());
+  const clientSecret = generateSecretKey();
+  const keypair = new NWCWalletServiceKeyPair(
+    walletSecret,
+    getPublicKey(clientSecret),
+  );
+
+  const service = new NWCWalletService({
+    relayUrls: ["wss://relay.getalby.com/v1"],
+  });
+
+  const publishedEvents: Event[] = [];
+  service.pool.publish = (_relayUrls, event) => {
+    publishedEvents.push(event);
+    return [Promise.resolve("")];
+  };
+  (
+    service as unknown as { _checkConnected: () => Promise<void> }
+  )._checkConnected = () => Promise.resolve();
+
+  return { service, keypair, publishedEvents };
+}
+
+describe("publishNotification", () => {
+  test("publishes a nip44_v2 notification (kind 23197) by default", async () => {
+    const { service, keypair, publishedEvents } = setupWalletService();
+
+    await service.publishNotification(keypair, paymentReceivedNotification);
+
+    expect(publishedEvents).toHaveLength(1);
+    const event = publishedEvents[0];
+    expect(event.kind).toBe(23197);
+    expect(event.pubkey).toBe(keypair.walletPubkey);
+    expect(event.tags).toEqual([["p", keypair.clientPubkey]]);
+    expect(
+      JSON.parse(await service.decrypt(keypair, event.content, "nip44_v2")),
+    ).toEqual(paymentReceivedNotification);
+  });
+
+  test("publishes both encryption kinds when requested", async () => {
+    const { service, keypair, publishedEvents } = setupWalletService();
+
+    await service.publishNotification(keypair, paymentReceivedNotification, {
+      encryptionTypes: ["nip44_v2", "nip04"],
+    });
+
+    expect(publishedEvents.map((event) => event.kind).sort()).toEqual([
+      23196, 23197,
+    ]);
+
+    const nip04Event = publishedEvents.find((event) => event.kind === 23196);
+    const nip44Event = publishedEvents.find((event) => event.kind === 23197);
+    if (!nip04Event || !nip44Event) {
+      throw new Error("expected both notification kinds");
+    }
+
+    expect(
+      JSON.parse(await service.decrypt(keypair, nip04Event.content, "nip04")),
+    ).toEqual(paymentReceivedNotification);
+    expect(
+      JSON.parse(
+        await service.decrypt(keypair, nip44Event.content, "nip44_v2"),
+      ),
+    ).toEqual(paymentReceivedNotification);
+  });
+
+  test("retries failed publishes with exponential backoff", async () => {
+    const { service, keypair } = setupWalletService();
+
+    let publishCalls = 0;
+    service.pool.publish = () => {
+      publishCalls++;
+      return [
+        publishCalls < 2
+          ? Promise.reject(new Error("publish failed"))
+          : Promise.resolve(""),
+      ];
+    };
+
+    const publishPromise = service.publishNotification(
+      keypair,
+      paymentReceivedNotification,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(publishCalls).toBe(1);
+
+    await publishPromise;
+    expect(publishCalls).toBe(2);
+  }, 10_000);
 });

--- a/src/nwc/NWCWalletService.test.ts
+++ b/src/nwc/NWCWalletService.test.ts
@@ -305,27 +305,10 @@ function setupWalletService() {
 }
 
 describe("publishNotification", () => {
-  test("publishes a nip44_v2 notification (kind 23197) by default", async () => {
+  test("publishes both encryption kinds by default", async () => {
     const { service, keypair, publishedEvents } = setupWalletService();
 
     await service.publishNotification(keypair, paymentReceivedNotification);
-
-    expect(publishedEvents).toHaveLength(1);
-    const event = publishedEvents[0];
-    expect(event.kind).toBe(23197);
-    expect(event.pubkey).toBe(keypair.walletPubkey);
-    expect(event.tags).toEqual([["p", keypair.clientPubkey]]);
-    expect(
-      JSON.parse(await service.decrypt(keypair, event.content, "nip44_v2")),
-    ).toEqual(paymentReceivedNotification);
-  });
-
-  test("publishes both encryption kinds when requested", async () => {
-    const { service, keypair, publishedEvents } = setupWalletService();
-
-    await service.publishNotification(keypair, paymentReceivedNotification, {
-      encryptionTypes: ["nip44_v2", "nip04"],
-    });
 
     expect(publishedEvents.map((event) => event.kind).sort()).toEqual([
       23196, 23197,
@@ -337,12 +320,30 @@ describe("publishNotification", () => {
       throw new Error("expected both notification kinds");
     }
 
+    expect(nip44Event.pubkey).toBe(keypair.walletPubkey);
+    expect(nip44Event.tags).toEqual([["p", keypair.clientPubkey]]);
     expect(
       JSON.parse(await service.decrypt(keypair, nip04Event.content, "nip04")),
     ).toEqual(paymentReceivedNotification);
     expect(
       JSON.parse(
         await service.decrypt(keypair, nip44Event.content, "nip44_v2"),
+      ),
+    ).toEqual(paymentReceivedNotification);
+  });
+
+  test("publishes a single encryption kind when requested", async () => {
+    const { service, keypair, publishedEvents } = setupWalletService();
+
+    await service.publishNotification(keypair, paymentReceivedNotification, {
+      encryptionTypes: ["nip44_v2"],
+    });
+
+    expect(publishedEvents).toHaveLength(1);
+    expect(publishedEvents[0].kind).toBe(23197);
+    expect(
+      JSON.parse(
+        await service.decrypt(keypair, publishedEvents[0].content, "nip44_v2"),
       ),
     ).toEqual(paymentReceivedNotification);
   });
@@ -363,6 +364,7 @@ describe("publishNotification", () => {
     const publishPromise = service.publishNotification(
       keypair,
       paymentReceivedNotification,
+      { encryptionTypes: ["nip44_v2"] },
     );
 
     await new Promise((resolve) => setTimeout(resolve, 100));

--- a/src/nwc/NWCWalletService.ts
+++ b/src/nwc/NWCWalletService.ts
@@ -21,6 +21,7 @@ import {
   Nip47SignMessageRequest,
   Nip47SingleMethod,
   Nip47EncryptionType,
+  Nip47Notification,
 } from "./types";
 import {
   NWCWalletServiceRequestHandler,
@@ -104,6 +105,65 @@ export class NWCWalletService {
       await Promise.any(this.pool.publish(this.relayUrls, event));
     } catch (error) {
       console.error("failed to publish wallet service info event", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Publish a NIP-47 notification to the connected client.
+   * Kind 23197 is used for nip44_v2 and kind 23196 for nip04.
+   * Pass both encryption types when the wallet service advertises both.
+   */
+  async publishNotification(
+    keypair: NWCWalletServiceKeyPair,
+    notification: Nip47Notification,
+    options?: {
+      /** default: ['nip44_v2'] — pass both for broader client interop */
+      encryptionTypes?: Nip47EncryptionType[];
+    },
+  ): Promise<void> {
+    try {
+      await this._checkConnected();
+
+      const encryptionTypes = [
+        ...new Set<Nip47EncryptionType>(
+          options?.encryptionTypes ?? ["nip44_v2"],
+        ),
+      ];
+      if (!encryptionTypes.length) {
+        throw new Error("encryptionTypes must not be empty");
+      }
+
+      const payload = JSON.stringify(notification);
+
+      await Promise.all(
+        encryptionTypes.map(async (encryptionType) => {
+          const eventTemplate: EventTemplate = {
+            kind: encryptionType === "nip04" ? 23196 : 23197,
+            created_at: Math.floor(Date.now() / 1000),
+            tags: [["p", keypair.clientPubkey]],
+            content: await this.encrypt(keypair, payload, encryptionType),
+          };
+
+          const event = await this.signEvent(
+            eventTemplate,
+            keypair.walletSecret,
+          );
+
+          const published = await this._publishWithRetry(
+            event,
+            () => this.pool.closed,
+          );
+          if (!published) {
+            throw new Nip47NetworkError(
+              "Failed to publish notification event",
+              "OTHER",
+            );
+          }
+        }),
+      );
+    } catch (error) {
+      console.error("failed to publish notification event", error);
       throw error;
     }
   }
@@ -267,27 +327,31 @@ export class NWCWalletService {
     };
   }
 
-  private async _publishWithRetry(event: Event, isStopped: () => boolean) {
+  private async _publishWithRetry(
+    event: Event,
+    isStopped: () => boolean,
+  ): Promise<boolean> {
     for (let attempt = 0; attempt < MAX_PUBLISH_ATTEMPTS; attempt++) {
       if (attempt > 0) {
         const delay = INITIAL_PUBLISH_RETRY_DELAY_MS * 2 ** (attempt - 1);
         await new Promise((resolve) => setTimeout(resolve, delay));
       }
       if (isStopped() || this.pool.closed) {
-        return;
+        return false;
       }
       try {
         // Try to publish to at least one relay
         await Promise.any(this.pool.publish(this.relayUrls, event));
-        return;
+        return true;
       } catch (error) {
         console.error(
-          `failed to publish response event (attempt ${attempt + 1}/${MAX_PUBLISH_ATTEMPTS})`,
+          `failed to publish event (attempt ${attempt + 1}/${MAX_PUBLISH_ATTEMPTS})`,
           event.id,
           error,
         );
       }
     }
+    return false;
   }
 
   get connected() {

--- a/src/nwc/NWCWalletService.ts
+++ b/src/nwc/NWCWalletService.ts
@@ -112,30 +112,18 @@ export class NWCWalletService {
 
   /**
    * Publish a NIP-47 notification to the connected client.
-   * Kind 23197 is used for nip44_v2 and kind 23196 for nip04.
-   * Defaults to both encryption types advertised on the info event
-   * (`nip44_v2` kind 23197 and `nip04` kind 23196).
+   * Always publishes both encryption kinds advertised on the info event:
+   * nip44_v2 (kind 23197) and nip04 (kind 23196).
    */
   async publishNotification(
     keypair: NWCWalletServiceKeyPair,
     notification: Nip47Notification,
-    options?: {
-      /** default: ['nip44_v2', 'nip04'] — matches the info event encryption tag */
-      encryptionTypes?: Nip47EncryptionType[];
-    },
   ): Promise<void> {
     try {
       await this._checkConnected();
 
-      const encryptionTypes = [
-        ...new Set<Nip47EncryptionType>(
-          options?.encryptionTypes ?? ["nip44_v2", "nip04"],
-        ),
-      ];
-      if (!encryptionTypes.length) {
-        throw new Error("encryptionTypes must not be empty");
-      }
-
+      // Match publishWalletServiceInfoEvent's hardcoded encryption tag.
+      const encryptionTypes: Nip47EncryptionType[] = ["nip44_v2", "nip04"];
       const payload = JSON.stringify(notification);
 
       await Promise.all(

--- a/src/nwc/NWCWalletService.ts
+++ b/src/nwc/NWCWalletService.ts
@@ -13,6 +13,7 @@ import {
   Nip47MakeInvoiceRequest,
   Nip47Method,
   Nip47NetworkError,
+  Nip47PublishError,
   Nip47NotificationType,
   Nip47PayInvoiceRequest,
   Nip47PayKeysendRequest,
@@ -112,13 +113,14 @@ export class NWCWalletService {
   /**
    * Publish a NIP-47 notification to the connected client.
    * Kind 23197 is used for nip44_v2 and kind 23196 for nip04.
-   * Pass both encryption types when the wallet service advertises both.
+   * Defaults to both encryption types advertised on the info event
+   * (`nip44_v2` kind 23197 and `nip04` kind 23196).
    */
   async publishNotification(
     keypair: NWCWalletServiceKeyPair,
     notification: Nip47Notification,
     options?: {
-      /** default: ['nip44_v2'] — pass both for broader client interop */
+      /** default: ['nip44_v2', 'nip04'] — matches the info event encryption tag */
       encryptionTypes?: Nip47EncryptionType[];
     },
   ): Promise<void> {
@@ -127,7 +129,7 @@ export class NWCWalletService {
 
       const encryptionTypes = [
         ...new Set<Nip47EncryptionType>(
-          options?.encryptionTypes ?? ["nip44_v2"],
+          options?.encryptionTypes ?? ["nip44_v2", "nip04"],
         ),
       ];
       if (!encryptionTypes.length) {
@@ -150,14 +152,11 @@ export class NWCWalletService {
             keypair.walletSecret,
           );
 
-          const published = await this._publishWithRetry(
-            event,
-            () => this.pool.closed,
-          );
+          const published = await this._publishWithRetry(event);
           if (!published) {
-            throw new Nip47NetworkError(
+            throw new Nip47PublishError(
               "Failed to publish notification event",
-              "OTHER",
+              "INTERNAL",
             );
           }
         }),
@@ -329,7 +328,7 @@ export class NWCWalletService {
 
   private async _publishWithRetry(
     event: Event,
-    isStopped: () => boolean,
+    isStopped: () => boolean = () => false, // default to not stopping
   ): Promise<boolean> {
     for (let attempt = 0; attempt < MAX_PUBLISH_ATTEMPTS; attempt++) {
       if (attempt > 0) {


### PR DESCRIPTION
## Summary

Adds `NWCWalletService.publishNotification()` so wallet services can publish NIP-47 notifications (`payment_received`, `payment_sent`, `hold_invoice_accepted`) to connected clients.

Closes #582

## Changes

- **New API**: `publishNotification(keypair, notification)` on `NWCWalletService`
- Publishes both encryption kinds for compatibility:
  - `nip44_v2` (kind `23197`)
  - `nip04` (kind `23196`)
- Reuses existing `_publishWithRetry` for reliable delivery with exponential backoff
- Adds unit tests covering dual-encryption publish and retry behavior
- Updates documentation (`docs/nwc.md`, `docs/nwc-wallet-service.md`)
- Adds runnable wallet-service examples demonstrating info advertising + notification publishing

## Usage

```ts
await walletService.publishNotification(keypair, {
  notification_type: "payment_sent",
  notification: transaction, // Nip47Transaction
});

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet services now publish payment notifications in both NIP-44 and NIP-04 formats.
  * Added a runnable wallet-service notification example with payment handling and notification publishing.
  * Added documentation for subscribing to wallet notifications and supported notification types.

* **Documentation**
  * Clarified relay URLs, key pairs, replay bounds, idempotency, and notification publishing.
  * Added complete usage examples and documented automatic dual-format notification encryption.

* **Bug Fixes**
  * Improved notification publishing reliability with retry handling when initial publication attempts fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->