### PR TITLE
fix: validate payment and invoice amounts client-side

### DIFF
--- a/src/lnclient/Amount.test.ts
+++ b/src/lnclient/Amount.test.ts
@@ -5,11 +5,13 @@ describe("Amount", () => {
     const amount = SATS(10);
     expect(amount.satoshi).toBe(10);
   });
+
   test("resolveAmount", async () => {
     const resolved = await resolveAmount({ satoshi: 10 });
     expect(resolved.satoshi).toBe(10);
     expect(resolved.millisat).toBe(10_000);
   });
+
   test("resolveAmount async", async () => {
     const resolved = await resolveAmount({
       satoshi: new Promise((resolve) => setTimeout(() => resolve(10), 300)),
@@ -17,4 +19,26 @@ describe("Amount", () => {
     expect(resolved.satoshi).toBe(10);
     expect(resolved.millisat).toBe(10_000);
   });
+
+  test("resolveAmount converts large valid amounts", async () => {
+    const resolved = await resolveAmount({ satoshi: 1_000_000 });
+    expect(resolved.satoshi).toBe(1_000_000);
+    expect(resolved.millisat).toBe(1_000_000_000);
+  });
+
+  test.each([0, -1, 1.5, NaN, Infinity])(
+    "SATS rejects invalid amount %s",
+    (amount) => {
+      expect(() => SATS(amount)).toThrow(/Invalid amount/);
+    },
+  );
+
+  test.each([0, -1, 1.5, NaN, Infinity])(
+    "resolveAmount rejects invalid amount %s",
+    async (amount) => {
+      await expect(resolveAmount({ satoshi: amount })).rejects.toThrow(
+        /Invalid amount/,
+      );
+    },
+  );
 });

--- a/src/lnclient/Amount.ts
+++ b/src/lnclient/Amount.ts
@@ -1,3 +1,5 @@
+import { assertPositiveIntegerAmount, satoshiToMillisat } from "../utils";
+
 // TODO: move to lightning tools
 /**
  * An amount in satoshis
@@ -5,22 +7,18 @@
 export type Amount = { satoshi: number } | { satoshi: Promise<number> };
 
 export const SATS: (amount: number) => Amount = (amount) => ({
-  satoshi: amount,
+  satoshi: assertPositiveIntegerAmount(amount),
 });
 
 export async function resolveAmount(
   amount: Amount,
 ): Promise<{ satoshi: number; millisat: number }> {
-  if (typeof amount === "number") {
-    return {
-      satoshi: amount,
-      millisat: amount * 1000,
-    };
-  }
-  const satoshi = await Promise.resolve(amount.satoshi);
+  const satoshi = assertPositiveIntegerAmount(
+    await Promise.resolve(amount.satoshi),
+  );
 
   return {
-    satoshi: satoshi,
-    millisat: satoshi * 1000,
+    satoshi,
+    millisat: satoshiToMillisat(satoshi),
   };
 }

--- a/src/nwc/NWCClient.test.ts
+++ b/src/nwc/NWCClient.test.ts
@@ -1,3 +1,4 @@
+import { jest } from "@jest/globals";
 import { NWCClient } from "./NWCClient";
 
 // this has no funds on it, I think ;-)
@@ -107,6 +108,99 @@ describe("NWCClient", () => {
     );
     expect(nwcClient.lud16).toBe("hello@getalby.com");
     expect(nwcClient.options.lud16).toBe("hello@getalby.com");
+  });
+});
+
+describe("NWCClient amount validation", () => {
+  const client = new NWCClient({ nostrWalletConnectUrl: exampleNwcUrl });
+  const paymentHash =
+    "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+  const pubkey =
+    "69effe7b49a6dd5cf525bd0905917a5005ffe480b58eeb8e861418cf3ae760d9";
+
+  test.each([0, -1, 1.5, NaN])(
+    "makeInvoice rejects invalid amount %s",
+    async (amount) => {
+      await expect(client.makeInvoice({ amount })).rejects.toThrow(
+        /Invalid amount/,
+      );
+    },
+  );
+
+  test.each([0, -1, 1.5, NaN])(
+    "makeHoldInvoice rejects invalid amount %s",
+    async (amount) => {
+      await expect(
+        client.makeHoldInvoice({ amount, payment_hash: paymentHash }),
+      ).rejects.toThrow(/Invalid amount/);
+    },
+  );
+
+  test.each([0, -1, 1.5, NaN])(
+    "payKeysend rejects invalid amount %s",
+    async (amount) => {
+      await expect(client.payKeysend({ amount, pubkey })).rejects.toThrow(
+        /Invalid amount/,
+      );
+    },
+  );
+
+  test.each([0, -1, 1.5, NaN])(
+    "payInvoice rejects invalid optional amount %s",
+    async (amount) => {
+      await expect(
+        client.payInvoice({ invoice: "lnbc1test", amount }),
+      ).rejects.toThrow(/Invalid amount/);
+    },
+  );
+
+  test("payInvoice rejects explicit null amount", async () => {
+    await expect(
+      client.payInvoice({
+        invoice: "lnbc1test",
+        amount: null as unknown as number,
+      }),
+    ).rejects.toThrow(/No amount specified/);
+  });
+
+  test("payInvoice allows omitted amount for zero-amount invoices", async () => {
+    const executeNip47Request = jest
+      .spyOn(
+        client as unknown as {
+          executeNip47Request: () => Promise<unknown>;
+        },
+        "executeNip47Request",
+      )
+      .mockResolvedValue({ preimage: "00", fees_paid: 0 });
+
+    await client.payInvoice({ invoice: "lnbc1test" });
+
+    expect(executeNip47Request).toHaveBeenCalled();
+    executeNip47Request.mockRestore();
+  });
+
+  test("multiPayInvoice rejects explicit null amount", async () => {
+    await expect(
+      client.multiPayInvoice({
+        invoices: [{ invoice: "lnbc1test", amount: null as unknown as number }],
+      }),
+    ).rejects.toThrow(/No amount specified/);
+  });
+
+  test("multiPayInvoice rejects invalid optional amount", async () => {
+    await expect(
+      client.multiPayInvoice({
+        invoices: [{ invoice: "lnbc1test", amount: 0 }],
+      }),
+    ).rejects.toThrow(/Invalid amount/);
+  });
+
+  test("multiPayKeysend rejects invalid amount", async () => {
+    await expect(
+      client.multiPayKeysend({
+        keysends: [{ amount: 0, pubkey }],
+      }),
+    ).rejects.toThrow(/Invalid amount/);
   });
 });
 

--- a/src/nwc/NWCClient.ts
+++ b/src/nwc/NWCClient.ts
@@ -56,6 +56,7 @@ import {
   Nip47NetworkError,
 } from "./types";
 import { ReconnectingPool } from "./ReconnectingPool";
+import { assertPositiveIntegerAmount } from "../utils";
 
 const NWC_HEX64 = /^[0-9a-f]{64}$/;
 
@@ -512,6 +513,10 @@ export class NWCClient {
 
   async payInvoice(request: Nip47PayInvoiceRequest): Promise<Nip47PayResponse> {
     try {
+      if (request.amount !== undefined) {
+        assertPositiveIntegerAmount(request.amount);
+      }
+
       const result = await this.executeNip47Request<Nip47PayResponse>(
         "pay_invoice",
         request,
@@ -526,6 +531,7 @@ export class NWCClient {
 
   async payKeysend(request: Nip47PayKeysendRequest): Promise<Nip47PayResponse> {
     try {
+      assertPositiveIntegerAmount(request.amount);
       const result = await this.executeNip47Request<Nip47PayResponse>(
         "pay_keysend",
         request,
@@ -578,6 +584,12 @@ export class NWCClient {
     request: Nip47MultiPayInvoiceRequest,
   ): Promise<Nip47MultiPayInvoiceResponse> {
     try {
+      for (const invoiceRequest of request.invoices) {
+        if (invoiceRequest.amount !== undefined) {
+          assertPositiveIntegerAmount(invoiceRequest.amount);
+        }
+      }
+
       const results = await this.executeMultiNip47Request<
         { invoice: Nip47PayInvoiceRequest } & Nip47PayResponse
       >(
@@ -602,6 +614,10 @@ export class NWCClient {
     request: Nip47MultiPayKeysendRequest,
   ): Promise<Nip47MultiPayKeysendResponse> {
     try {
+      for (const keysendRequest of request.keysends) {
+        assertPositiveIntegerAmount(keysendRequest.amount);
+      }
+
       const results = await this.executeMultiNip47Request<
         { keysend: Nip47PayKeysendRequest } & Nip47PayResponse
       >(
@@ -626,9 +642,7 @@ export class NWCClient {
     request: Nip47MakeInvoiceRequest,
   ): Promise<Nip47Transaction> {
     try {
-      if (!request.amount) {
-        throw new Error("No amount specified");
-      }
+      assertPositiveIntegerAmount(request.amount);
 
       const result = await this.executeNip47Request<Nip47Transaction>(
         "make_invoice",
@@ -647,9 +661,7 @@ export class NWCClient {
     request: Nip47MakeHoldInvoiceRequest,
   ): Promise<Nip47Transaction> {
     try {
-      if (!request.amount) {
-        throw new Error("No amount specified");
-      }
+      assertPositiveIntegerAmount(request.amount);
       if (!request.payment_hash) {
         throw new Error("No payment hash specified");
       }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,76 @@
+import { assertPositiveIntegerAmount, satoshiToMillisat } from "./utils";
+
+describe("assertPositiveIntegerAmount", () => {
+  test("accepts valid amounts", () => {
+    expect(assertPositiveIntegerAmount(1)).toBe(1);
+    expect(assertPositiveIntegerAmount(1000)).toBe(1000);
+    expect(assertPositiveIntegerAmount(Number.MAX_SAFE_INTEGER)).toBe(
+      Number.MAX_SAFE_INTEGER,
+    );
+  });
+
+  test("returns the same number when valid", () => {
+    const amount = 42_000;
+    expect(assertPositiveIntegerAmount(amount)).toBe(amount);
+  });
+
+  test("uses custom label in error messages", () => {
+    expect(() => assertPositiveIntegerAmount(undefined, "tip")).toThrow(
+      "No tip specified",
+    );
+    expect(() => assertPositiveIntegerAmount(0, "tip")).toThrow(
+      "Invalid tip: must be at least 1",
+    );
+  });
+
+  test.each([
+    [undefined, "No amount specified"],
+    [null, "No amount specified"],
+    [0, "Invalid amount: must be at least 1"],
+    [-1, "Invalid amount: must be at least 1"],
+    [1.5, "Invalid amount: must be an integer"],
+    [NaN, "Invalid amount: must be a finite number"],
+    [Infinity, "Invalid amount: must be a finite number"],
+    [-Infinity, "Invalid amount: must be a finite number"],
+    [
+      Number.MAX_SAFE_INTEGER + 1,
+      "Invalid amount: exceeds maximum allowed value",
+    ],
+  ])("rejects %s", (amount, message) => {
+    expect(() => assertPositiveIntegerAmount(amount)).toThrow(message);
+  });
+
+  test("rejects non-number types", () => {
+    expect(() => assertPositiveIntegerAmount("1000")).toThrow(
+      "Invalid amount: must be a finite number",
+    );
+    expect(() => assertPositiveIntegerAmount(true)).toThrow(
+      "Invalid amount: must be a finite number",
+    );
+  });
+});
+
+describe("satoshiToMillisat", () => {
+  test("converts satoshis to millisats", () => {
+    expect(satoshiToMillisat(1)).toBe(1_000);
+    expect(satoshiToMillisat(10)).toBe(10_000);
+    expect(satoshiToMillisat(21)).toBe(21_000);
+  });
+
+  test("converts max safe satoshi value", () => {
+    const maxSatoshi = Math.floor(Number.MAX_SAFE_INTEGER / 1000);
+    expect(satoshiToMillisat(maxSatoshi)).toBe(maxSatoshi * 1000);
+  });
+
+  test("rejects invalid satoshi values", () => {
+    expect(() => satoshiToMillisat(0)).toThrow(/Invalid amount/);
+    expect(() => satoshiToMillisat(-1)).toThrow(/Invalid amount/);
+  });
+
+  test("rejects values that overflow millisat representation", () => {
+    const maxSatoshi = Math.floor(Number.MAX_SAFE_INTEGER / 1000);
+    expect(() => satoshiToMillisat(maxSatoshi + 1)).toThrow(
+      /exceeds maximum allowed value after conversion to millisats/,
+    );
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,4 +15,42 @@ async function generatePreimageAndPaymentHash(): Promise<{
   return { preimage, paymentHash };
 }
 
-export { toHexString, generatePreimageAndPaymentHash };
+function assertPositiveIntegerAmount(
+  amount: unknown,
+  label = "amount",
+): number {
+  if (amount === undefined || amount === null) {
+    throw new Error(`No ${label} specified`);
+  }
+  if (typeof amount !== "number" || !Number.isFinite(amount)) {
+    throw new Error(`Invalid ${label}: must be a finite number`);
+  }
+  if (!Number.isInteger(amount)) {
+    throw new Error(`Invalid ${label}: must be an integer`);
+  }
+  if (amount < 1) {
+    throw new Error(`Invalid ${label}: must be at least 1`);
+  }
+  if (amount > Number.MAX_SAFE_INTEGER) {
+    throw new Error(`Invalid ${label}: exceeds maximum allowed value`);
+  }
+  return amount;
+}
+
+function satoshiToMillisat(satoshi: number): number {
+  const validSatoshi = assertPositiveIntegerAmount(satoshi, "amount");
+  const millisat = validSatoshi * 1000;
+  if (!Number.isSafeInteger(millisat)) {
+    throw new Error(
+      "Amount exceeds maximum allowed value after conversion to millisats",
+    );
+  }
+  return millisat;
+}
+
+export {
+  toHexString,
+  generatePreimageAndPaymentHash,
+  assertPositiveIntegerAmount,
+  satoshiToMillisat,
+};


### PR DESCRIPTION
## Summary

### Problem

The SDK had almost no client-side amount validation. Methods such as `makeInvoice`, `makeHoldInvoice`, and payment flows only checked whether an amount was present:

```ts
if (!request.amount) {
  throw new Error("No amount specified");
}
```

This meant invalid values could be accepted and only fail later at the wallet, including:

- `0`, negative numbers, `NaN`, non-integers, and `Infinity`
- Very large values without range or overflow checks
- Unsafe sats → msats conversion using `* 1000` in `LNClient` and `resolveAmount`

Apps could therefore accidentally create or attempt payments with invalid amounts. While wallets would usually reject them, the failures happened late and could produce unclear errors.

### Fix

Added shared validation utilities in `utils.ts`:

- **`assertPositiveIntegerAmount`** — rejects missing, non-finite, non-integer, zero/negative, and unsafe integer values
- **`satoshiToMillisat`** — validates satoshi amounts before converting them to millisats and protects against overflow

Applied validation to:

- **`NWCClient`**
  - `makeInvoice`
  - `makeHoldInvoice`
  - `payKeysend`
  - `multiPayKeysend`
  - Optional `amount` in `payInvoice`
  - Optional `amount` in `multiPayInvoice`

- **`LNClient`**
  - `SATS()`
  - `resolveAmount()`

Invalid amounts now fail immediately with clear errors before any NWC request is sent.

### Notes

- `payInvoice` and `multiPayInvoice` still allow an **omitted** `amount` for normal and zero-amount invoices. Validation only runs when `amount` is explicitly provided.
- When paying a zero-amount invoice, callers must provide a **positive** `amount` representing the amount they intend to pay, not `0`.
- Wallet-side balance and budget enforcement remain unchanged. This PR only adds client-side format and range validation.

## Test Plan

```bash
yarn test src/utils.test.ts src/lnclient/Amount.test.ts src/nwc/NWCClient.test.ts
```

```bash
yarn typecheck
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation to ensure payment and invoice amounts are positive whole numbers.
  - Invalid amounts—including zero, negative, fractional, non-finite, and overly large values—are now rejected before requests are sent.
  - Improved satoshi-to-millisatoshi conversion safeguards to prevent overflow.
  - Zero-amount invoices can still be paid when no amount is provided.
- **Tests**
  - Expanded coverage for valid amounts, invalid inputs, payment flows, and conversion boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->