### PR TITLE
fix: move @webbtc/webln-types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "@getalby/lightning-tools": "^8.1.1",
+    "@webbtc/webln-types": "^3.0.0",
     "nostr-tools": "^2.23.3"
   },
   "devDependencies": {
@@ -86,7 +87,6 @@
     "@types/node": "^25.7.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^6.3.0",
-    "@webbtc/webln-types": "^3.0.0",
     "eslint": "^8.46.0",
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",

--- a/src/oauth/client.ts
+++ b/src/oauth/client.ts
@@ -1,4 +1,4 @@
-import { SignMessageResponse } from "@webbtc/webln-types";
+import type { SignMessageResponse } from "@webbtc/webln-types";
 import { OAuth2Bearer } from "./auth";
 import { keysendParamsFromBoostagram } from "./helpers";
 import { RequestOptions, rest } from "./request";

--- a/src/webln-types-consumer.smoke.test.ts
+++ b/src/webln-types-consumer.smoke.test.ts
@@ -1,0 +1,109 @@
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const pkg = JSON.parse(
+  readFileSync(path.join(repoRoot, "package.json"), "utf8"),
+) as {
+  version: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+
+function run(cmd: string, args: string[], cwd: string): string {
+  try {
+    return execFileSync(cmd, args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; message: string };
+    throw new Error(
+      `${cmd} ${args.join(" ")}\n${e.stdout ?? ""}\n${e.stderr ?? ""}\n${e.message}`,
+    );
+  }
+}
+
+describe("@webbtc/webln-types consumer packaging", () => {
+  test("is listed in dependencies so published d.ts imports resolve", () => {
+    expect(pkg.dependencies?.["@webbtc/webln-types"]).toBeTruthy();
+    expect(pkg.devDependencies?.["@webbtc/webln-types"]).toBeUndefined();
+  });
+
+  test("a clean TypeScript consumer typechecks without installing webln-types by hand", () => {
+    const distTypes = path.join(repoRoot, "dist/types/index.d.ts");
+    if (!existsSync(distTypes)) {
+      throw new Error("dist/types missing; run yarn build before yarn test");
+    }
+
+    const dir = mkdtempSync(path.join(tmpdir(), "getalby-sdk-consumer-"));
+    try {
+      writeFileSync(
+        path.join(dir, "package.json"),
+        JSON.stringify({
+          name: "getalby-sdk-webln-types-consumer",
+          private: true,
+          type: "module",
+        }),
+      );
+      writeFileSync(
+        path.join(dir, "tsconfig.json"),
+        JSON.stringify({
+          compilerOptions: {
+            module: "NodeNext",
+            moduleResolution: "NodeNext",
+            target: "ES2022",
+            strict: true,
+            skipLibCheck: false,
+            noEmit: true,
+          },
+          include: ["index.ts"],
+        }),
+      );
+      writeFileSync(
+        path.join(dir, "index.ts"),
+        [
+          'import { NostrWebLNProvider } from "@getalby/sdk";',
+          'import { Client } from "@getalby/sdk/oauth";',
+          "export type Provider = NostrWebLNProvider;",
+          "export type OAuthClient = Client;",
+        ].join("\n"),
+      );
+
+      run(
+        "npm",
+        ["pack", "--ignore-scripts", "--pack-destination", dir],
+        repoRoot,
+      );
+      const tarball = path.join(dir, `getalby-sdk-${pkg.version}.tgz`);
+      expect(existsSync(tarball)).toBe(true);
+
+      run("npm", ["install", "--omit=dev", tarball], dir);
+
+      const consumerPkg = JSON.parse(
+        readFileSync(path.join(dir, "package.json"), "utf8"),
+      ) as {
+        dependencies?: Record<string, string>;
+        devDependencies?: Record<string, string>;
+      };
+      expect(consumerPkg.dependencies?.["@webbtc/webln-types"]).toBeUndefined();
+      expect(
+        consumerPkg.devDependencies?.["@webbtc/webln-types"],
+      ).toBeUndefined();
+
+      const tsc = path.join(repoRoot, "node_modules/typescript/bin/tsc");
+      run(tsc, ["--noEmit", "-p", "tsconfig.json"], dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 120000);
+});

--- a/src/webln/NostrWeblnProvider.ts
+++ b/src/webln/NostrWeblnProvider.ts
@@ -1,19 +1,19 @@
 import { Event, UnsignedEvent } from "nostr-tools";
-import {
+import type {
   GetBalanceResponse,
+  GetInfoResponse,
   KeysendArgs,
+  LookupInvoiceArgs,
+  LookupInvoiceResponse,
+  MakeInvoiceResponse,
   RequestInvoiceArgs,
   SendPaymentResponse,
   SignMessageResponse,
+  WebLNMethod,
   WebLNNode,
   WebLNProvider,
   WebLNRequestMethod,
-  LookupInvoiceArgs,
-  LookupInvoiceResponse,
-  WebLNMethod,
-  MakeInvoiceResponse,
 } from "@webbtc/webln-types";
-import { GetInfoResponse } from "@webbtc/webln-types";
 import { NWCClient, NWCOptions, NewNWCClientOptions } from "../nwc/NWCClient";
 import {
   Nip47Method,


### PR DESCRIPTION
Published `.d.ts` files import `@webbtc/webln-types`, but that package was only listed under `devDependencies`. TypeScript consumers that do not install it themselves fail with:

```
Cannot find module '@webbtc/webln-types' or its corresponding type declarations.
```

`import type` is used at the source import sites. The published declarations still re-export those types, so the package is moved to `dependencies` so package managers install it for consumers.

A smoke test packs the SDK and typechecks a clean TypeScript project that does not add `@webbtc/webln-types` itself.

Fixes #234

Reported by @rolznz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured published packages include the WebLN type definitions required for consumers to typecheck successfully without additional manual installation.

* **Tests**
  * Added coverage verifying clean, production-only installations can compile consumer code using the SDK and OAuth APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->